### PR TITLE
feat: add a new filter key on the model view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BREAKING: allow registration of users with role from the API and reset password mechanism
 - Add address and permissions for `inputs` of kind datamanager and model in compute_tasks api response
 - Synchronize compute task output assets into localrep
+- `compute_task_key` filter on the model view.
 
 ## [0.28.0] 2022-08-29
 

--- a/backend/substrapp/views/model.py
+++ b/backend/substrapp/views/model.py
@@ -43,6 +43,7 @@ class ModelRepFilter(FilterSet):
         field_name="category",
         choices=ModelRep.Category.choices,
     )
+    compute_task_key = BaseInFilter(field_name="compute_task__key")
 
     class Meta:
         model = ModelRep


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Introduce a new filter param `compute_task_key` that makes it possible to filter models by the compute tasks that produced them.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is required because I need to filter models on the key of the compute tasks that produced them. This was introduced in the SDK in https://github.com/Substra/substra/pull/275 and I thought it would work with the filter `compute_task` but it was not the case since this filter only accept a single key and the SDK only sends lists for filters.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Using the Django API tool and using the SDK.
Let me know if I need to introduce a unit test for this, I did not do it since the `compute_task` filter was already untested.