### PR TITLE
chore: remove unused setting

### DIFF
--- a/backend/backend/settings/common.py
+++ b/backend/backend/settings/common.py
@@ -421,7 +421,5 @@ ISOLATED = to_bool(os.environ.get("ISOLATED"))
 
 CONTENT_DISPOSITION_HEADER = {}
 
-LOCALREP_RESYNC_EVENTS_PAGE_SIZE = int(os.environ.get("LOCALREP_RESYNC_EVENTS_PAGE_SIZE", 1000))
-
 # To encode unique jwt token generated with reset password request
 RESET_JWT_SIGNATURE_ALGORITHM = "HS256"

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -45,7 +45,6 @@ Accepted true values for `bool` are: `1`, `ON`, `On`, `on`, `T`, `t`, `TRUE`, `T
 | string | `KANIKO_DOCKER_CONFIG_SECRET_NAME` | nil |  |
 | string | `KANIKO_IMAGE` | nil |  |
 | bool | `KANIKO_MIRROR` | `False` |  |
-| int | `LOCALREP_RESYNC_EVENTS_PAGE_SIZE` | `1000` |  |
 | bool | `LOGGING_USE_COLORS` | `True` |  |
 | string | `LOG_LEVEL` | `INFO` |  |
 | string | `NAMESPACE` | nil |  |


### PR DESCRIPTION
Following this [comment](https://github.com/Substra/substra-backend/pull/442#issuecomment-1242078535)

This setting seems to not be used anymore, introduced [here](https://github.com/Substra/substra-backend/commit/f6f225b502e940914098f54ece4a51046e66b6f8), removed [here](https://github.com/Substra/substra-backend/commit/4a5a65b3ed7c0c96e2a303ae9ba37a3a562493d9#diff-bbc5395dcf594e6092a31c207b688fe64be94a974d0b4fcc1a4190cfb1494be5)

