### PR TITLE
ci: fix the labeler action permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   triage:
     permissions:
-      content: read
+      contents: read
       pull-requests: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I made a typo when creating the action in #446