### PR TITLE
chore: split substrapp utils

### DIFF
--- a/backend/api/errors.py
+++ b/backend/api/errors.py
@@ -1,4 +1,37 @@
+from rest_framework import response
+from rest_framework import status
+
+
 class AlreadyExistsError(Exception):
     """The asset was already created in the local representation"""
 
     pass
+
+
+class ApiError(Exception):
+    """Base error response returned by API."""
+
+    status = status.HTTP_500_INTERNAL_SERVER_ERROR
+    message = "Internal server error."
+
+    def __init__(self, message=None, data=None):
+        message = message or self.message
+
+        self.error = data or {}
+        self.error["message"] = message
+
+        super().__init__(message)
+
+    def response(self):
+        """Get HTTP Response from error instance."""
+        return response.Response(self.error, status=self.status)
+
+
+class BadRequestError(ApiError):
+    status = status.HTTP_400_BAD_REQUEST
+    message = "Bad request."
+
+
+class AssetPermissionError(Exception):
+    def __init__(self, message="Unauthorized"):
+        super().__init__(self, message)

--- a/backend/api/tests/common.py
+++ b/backend/api/tests/common.py
@@ -1,0 +1,84 @@
+import base64
+from http.cookies import SimpleCookie
+from unittest import mock
+
+from django.contrib.auth.models import User
+from requests import auth
+from rest_framework.test import APIClient
+
+from organization.models import IncomingOrganization
+from users.models.user_channel import UserChannel
+
+# This function helper generate a basic authentication header with given credentials
+# Given username and password it returns "Basic GENERATED_TOKEN"
+from users.serializers import CustomTokenObtainPairSerializer
+
+
+def generate_basic_auth_header(username, password):
+    return "Basic " + base64.b64encode(f"{username}:{password}".encode()).decode()
+
+
+def generate_jwt_auth_header(jwt):
+    return "JWT " + jwt
+
+
+class AuthenticatedClient(APIClient):
+    def __init__(self, enforce_csrf_checks=False, role=UserChannel.Role.USER, channel=None, **defaults):
+        super().__init__(enforce_csrf_checks, **defaults)
+        self.role = role
+        self.channel = channel
+
+    def request(self, **kwargs):
+        # create user
+        username = "substra"
+        password = "p@sswr0d44"
+        user, created = User.objects.get_or_create(username=username)
+        if created:
+            user.set_password(password)
+            user.save()
+            # for testing purpose most authentication are done without channel allowing to mock passing channel in
+            # header, this check is necessary to not break previous tests but irl a user cannot be created
+            # without a channel
+            if self.channel:
+                UserChannel.objects.create(user=user, channel_name=self.channel, role=self.role)
+
+        # simulate login
+        serializer = CustomTokenObtainPairSerializer(data={"username": username, "password": password})
+
+        serializer.is_valid()
+        data = serializer.validated_data
+        access_token = str(data.access_token)
+
+        # simulate right httpOnly cookie and Authorization jwt
+        jwt_auth_header = generate_jwt_auth_header(".".join(access_token.split(".")[0:2]))
+        self.credentials(HTTP_AUTHORIZATION=jwt_auth_header)
+        self.cookies = SimpleCookie({"signature": access_token.split(".")[2]})
+
+        return super().request(**kwargs)
+
+
+class AuthenticatedBackendClient(APIClient):
+    def request(self, **kwargs):
+
+        username = "MyTestOrg"
+        password = "p@sswr0d44"
+        try:
+            IncomingOrganization.objects.get(organization_id=username)
+        except IncomingOrganization.DoesNotExist:
+            IncomingOrganization.objects.create(organization_id=username, secret=password)
+
+        self.credentials(HTTP_AUTHORIZATION=auth._basic_auth_str(username, password))
+
+        return super().request(**kwargs)
+
+
+def internal_server_error_on_exception():
+    """Decorator factory to make the Django test client respond with '500 Internal Server Error'
+    when an unhandled exception occurs.
+
+    Once we update to Django 3, we can use the `raise_request_exception` parameter
+    of the test client: https://docs.djangoproject.com/en/3.2/topics/testing/tools/#making-requests.
+
+    Adapted from https://stackoverflow.com/a/62720158.
+    """
+    return mock.patch("django.test.client.Client.store_exc_info", mock.Mock())

--- a/backend/api/tests/views/conftest.py
+++ b/backend/api/tests/views/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from django import conf
 from rest_framework import test
 
-from substrapp.tests import common
+from api.tests.common import AuthenticatedClient
 
 _CHANNEL_NAME: Final[str] = "mychannel"
 _EXTRA_HTTP_HEADERS: Final[dict[str, str]] = {"HTTP_SUBSTRA_CHANNEL_NAME": _CHANNEL_NAME}
@@ -20,7 +20,7 @@ def _set_settings(settings: conf.Settings, tmp_path: pathlib.Path):
 
 @pytest.fixture
 def authenticated_client() -> test.APIClient:
-    client = common.AuthenticatedClient()
+    client = AuthenticatedClient()
 
     client.get = functools.partial(client.get, **_EXTRA_HTTP_HEADERS)
     client.post = functools.partial(client.post, **_EXTRA_HTTP_HEADERS)

--- a/backend/api/tests/views/test_utils.py
+++ b/backend/api/tests/views/test_utils.py
@@ -11,10 +11,10 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from api.tests import asset_factory as factory
+from api.tests.common import AuthenticatedClient
 from organization.authentication import OrganizationUser
 from organization.models import OutgoingOrganization
 from substrapp.models import Algo as AlgoFiles
-from substrapp.tests.common import AuthenticatedClient
 from substrapp.tests.common import get_description_algo
 from substrapp.tests.common import get_sample_algo
 

--- a/backend/api/tests/views/test_views_algo.py
+++ b/backend/api/tests/views/test_views_algo.py
@@ -14,11 +14,11 @@ from rest_framework.test import APITestCase
 
 from api.models import Algo
 from api.tests import asset_factory as factory
+from api.tests.common import AuthenticatedClient
+from api.tests.common import internal_server_error_on_exception
 from orchestrator.client import OrchestratorClient
 from orchestrator.error import OrcError
 from orchestrator.error import StatusCode
-from substrapp.tests.common import AuthenticatedClient
-from substrapp.tests.common import internal_server_error_on_exception
 from substrapp.utils import compute_hash
 
 MEDIA_ROOT = tempfile.mkdtemp()

--- a/backend/api/tests/views/test_views_authentication.py
+++ b/backend/api/tests/views/test_views_authentication.py
@@ -10,10 +10,10 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from api.tests import asset_factory as factory
+from api.tests.common import generate_basic_auth_header
 from organization.models import IncomingOrganization
 from organization.models import OutgoingOrganization
 from substrapp.models import Algo as AlgoFiles
-from substrapp.tests.common import generate_basic_auth_header
 from substrapp.tests.common import get_description_algo
 from substrapp.tests.common import get_sample_algo
 

--- a/backend/api/tests/views/test_views_compute_plan_graph.py
+++ b/backend/api/tests/views/test_views_compute_plan_graph.py
@@ -9,8 +9,8 @@ from rest_framework.test import APITestCase
 
 from api.models import ComputeTask
 from api.tests import asset_factory as factory
+from api.tests.common import AuthenticatedClient
 from api.views.compute_plan_graph import MAX_TASKS_DISPLAYED
-from substrapp.tests.common import AuthenticatedClient
 
 MEDIA_ROOT = tempfile.mkdtemp()
 

--- a/backend/api/tests/views/test_views_computeplan.py
+++ b/backend/api/tests/views/test_views_computeplan.py
@@ -17,10 +17,10 @@ from rest_framework.test import APITestCase
 from api.models import ComputePlan
 from api.models import ComputeTask
 from api.tests import asset_factory as factory
+from api.tests.common import AuthenticatedClient
+from api.tests.common import internal_server_error_on_exception
 from orchestrator.client import OrchestratorClient
 from orchestrator.error import OrcError
-from substrapp.tests.common import AuthenticatedClient
-from substrapp.tests.common import internal_server_error_on_exception
 
 MEDIA_ROOT = tempfile.mkdtemp()
 

--- a/backend/api/tests/views/test_views_computetask.py
+++ b/backend/api/tests/views/test_views_computetask.py
@@ -21,10 +21,10 @@ from api.serializers import AlgoSerializer
 from api.serializers import DataManagerSerializer
 from api.serializers import ModelSerializer
 from api.tests import asset_factory as factory
+from api.tests.common import AuthenticatedClient
+from api.tests.common import internal_server_error_on_exception
 from api.views.computetask import EXTRA_DATA_FIELD
 from orchestrator.client import OrchestratorClient
-from substrapp.tests.common import AuthenticatedClient
-from substrapp.tests.common import internal_server_error_on_exception
 
 MEDIA_ROOT = tempfile.mkdtemp()
 

--- a/backend/api/tests/views/test_views_datamanager.py
+++ b/backend/api/tests/views/test_views_datamanager.py
@@ -15,10 +15,10 @@ from rest_framework.test import APITestCase
 
 from api.models import DataManager
 from api.tests import asset_factory as factory
+from api.tests.common import AuthenticatedClient
+from api.tests.common import internal_server_error_on_exception
 from orchestrator.client import OrchestratorClient
 from orchestrator.error import OrcError
-from substrapp.tests.common import AuthenticatedClient
-from substrapp.tests.common import internal_server_error_on_exception
 from substrapp.utils import compute_hash
 
 MEDIA_ROOT = tempfile.mkdtemp()

--- a/backend/api/tests/views/test_views_datasample.py
+++ b/backend/api/tests/views/test_views_datasample.py
@@ -17,10 +17,10 @@ from rest_framework.test import APITestCase
 
 from api.models import DataSample
 from api.tests import asset_factory as factory
+from api.tests.common import AuthenticatedClient
+from api.tests.common import internal_server_error_on_exception
 from orchestrator.client import OrchestratorClient
 from orchestrator.error import OrcError
-from substrapp.tests.common import AuthenticatedClient
-from substrapp.tests.common import internal_server_error_on_exception
 from substrapp.utils import get_dir_hash
 
 MEDIA_ROOT = tempfile.mkdtemp()

--- a/backend/api/tests/views/test_views_info.py
+++ b/backend/api/tests/views/test_views_info.py
@@ -5,8 +5,8 @@ from rest_framework import status
 from rest_framework.test import APIClient
 from rest_framework.test import APITestCase
 
+from api.tests.common import AuthenticatedClient
 from orchestrator.client import OrchestratorClient
-from substrapp.tests.common import AuthenticatedClient
 
 
 @override_settings(LEDGER_CHANNELS={"mychannel": {"chaincode": {"name": "mycc"}, "model_export_enabled": True}})

--- a/backend/api/tests/views/test_views_metadata.py
+++ b/backend/api/tests/views/test_views_metadata.py
@@ -8,7 +8,7 @@ from rest_framework.test import APITestCase
 
 from api.models import ComputePlan
 from api.tests import asset_factory as factory
-from substrapp.tests.common import AuthenticatedClient
+from api.tests.common import AuthenticatedClient
 
 MEDIA_ROOT = tempfile.mkdtemp()
 

--- a/backend/api/tests/views/test_views_model.py
+++ b/backend/api/tests/views/test_views_model.py
@@ -12,15 +12,15 @@ from parameterized import parameterized
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api.errors import AssetPermissionError
 from api.models import ComputeTask
 from api.models import Model
 from api.tests import asset_factory as factory
+from api.tests.common import AuthenticatedClient
+from api.tests.common import internal_server_error_on_exception
 from api.views.model import ModelPermissionViewSet
-from api.views.utils import AssetPermissionError
 from organization.authentication import OrganizationUser
-from substrapp.tests.common import AuthenticatedClient
 from substrapp.tests.common import get_sample_model
-from substrapp.tests.common import internal_server_error_on_exception
 from substrapp.utils import compute_hash
 
 CHANNEL = "mychannel"

--- a/backend/api/tests/views/test_views_newsfeed.py
+++ b/backend/api/tests/views/test_views_newsfeed.py
@@ -11,7 +11,7 @@ from rest_framework.test import APITestCase
 from api.models import ComputePlan
 from api.models import ComputeTask
 from api.tests import asset_factory as factory
-from substrapp.tests.common import AuthenticatedClient
+from api.tests.common import AuthenticatedClient
 
 MEDIA_ROOT = tempfile.mkdtemp()
 

--- a/backend/api/tests/views/test_views_performance.py
+++ b/backend/api/tests/views/test_views_performance.py
@@ -13,7 +13,7 @@ from api.models import ComputePlan
 from api.models import ComputeTask
 from api.models import Performance
 from api.tests import asset_factory as factory
-from substrapp.tests.common import AuthenticatedClient
+from api.tests.common import AuthenticatedClient
 
 MEDIA_ROOT = tempfile.mkdtemp()
 

--- a/backend/api/tests/views/test_views_task_profiling.py
+++ b/backend/api/tests/views/test_views_task_profiling.py
@@ -6,8 +6,8 @@ from rest_framework.test import APITestCase
 
 from api.models import ComputeTask
 from api.tests import asset_factory as factory
-from substrapp.tests.common import AuthenticatedBackendClient
-from substrapp.tests.common import AuthenticatedClient
+from api.tests.common import AuthenticatedBackendClient
+from api.tests.common import AuthenticatedClient
 
 CHANNEL = "mychannel"
 TEST_ORG = "MyTestOrg"

--- a/backend/api/views/computeplan.py
+++ b/backend/api/views/computeplan.py
@@ -18,6 +18,7 @@ from rest_framework.filters import OrderingFilter
 from rest_framework.viewsets import GenericViewSet
 
 from api.errors import AlreadyExistsError
+from api.errors import BadRequestError
 from api.models import ComputePlan
 from api.serializers import ComputePlanSerializer
 from api.views.filters_utils import CharInFilter
@@ -28,7 +29,6 @@ from api.views.utils import ApiResponse
 from api.views.utils import get_channel_name
 from api.views.utils import to_string_uuid
 from libs.pagination import SmallPageNumberPagination
-from substrapp import exceptions
 from substrapp.orchestrator import get_orchestrator_client
 
 logger = structlog.get_logger(__name__)
@@ -88,7 +88,7 @@ def validate_status(key, values):
             for value in values:
                 getattr(ComputePlan.Status, value)
         except AttributeError as e:
-            raise exceptions.BadRequestError(f"Wrong {key} value: {e}")
+            raise BadRequestError(f"Wrong {key} value: {e}")
     return key, values
 
 

--- a/backend/api/views/computetask.py
+++ b/backend/api/views/computetask.py
@@ -18,6 +18,7 @@ from rest_framework.filters import OrderingFilter
 from rest_framework.viewsets import GenericViewSet
 
 from api.errors import AlreadyExistsError
+from api.errors import BadRequestError
 from api.models import ComputePlan
 from api.models import ComputeTask
 from api.serializers import ComputeTaskSerializer
@@ -34,7 +35,6 @@ from api.views.utils import get_channel_name
 from api.views.utils import validate_key
 from libs.pagination import DefaultPageNumberPagination
 from orchestrator import computetask
-from substrapp import exceptions
 from substrapp.orchestrator import get_orchestrator_client
 
 logger = structlog.get_logger(__name__)
@@ -174,9 +174,9 @@ def task_bulk_create_view(request):
     compute_plan_keys = [task["compute_plan_key"] for task in request.data["tasks"]]
     compute_plans = ComputePlan.objects.filter(key__in=compute_plan_keys)
     if len(compute_plans) == 0:
-        raise exceptions.BadRequestError("Invalid compute plan key")
+        raise BadRequestError("Invalid compute plan key")
     if len(compute_plans) > 1:
-        raise exceptions.BadRequestError("All tasks should have the same compute plan key")
+        raise BadRequestError("All tasks should have the same compute plan key")
     compute_plan = compute_plans[0]
     orc_data = _register_in_orchestrator(request.data["tasks"], get_channel_name(request))
 
@@ -207,7 +207,7 @@ def validate_status_and_map_cp_key(key, values):
             for value in values:
                 getattr(ComputeTask.Status, value)
         except AttributeError as e:
-            raise exceptions.BadRequestError(f"Wrong {key} value: {e}")
+            raise BadRequestError(f"Wrong {key} value: {e}")
     elif key == "compute_plan_key":
         key = "compute_plan_id"
     return key, values

--- a/backend/api/views/datasample.py
+++ b/backend/api/views/datasample.py
@@ -24,6 +24,7 @@ from rest_framework.filters import OrderingFilter
 from rest_framework.viewsets import GenericViewSet
 
 from api.errors import AlreadyExistsError
+from api.errors import BadRequestError
 from api.models import DataManager
 from api.models import DataSample
 from api.serializers import DataSampleSerializer
@@ -31,7 +32,6 @@ from api.views.filters_utils import CharInFilter
 from api.views.utils import ApiResponse
 from api.views.utils import get_channel_name
 from libs.pagination import DefaultPageNumberPagination
-from substrapp import exceptions
 from substrapp.exceptions import ServerMediasNoSubdirError
 from substrapp.models import DataManager as DataManagerFiles
 from substrapp.orchestrator import get_orchestrator_client
@@ -136,15 +136,15 @@ def _db_create(data):
     try:
         return serializer.save()
     except Exception as e:
-        raise exceptions.BadRequestError(str(e))
+        raise BadRequestError(str(e))
 
 
 def check_datamanagers(data_manager_keys):
     if not data_manager_keys:
-        raise exceptions.BadRequestError("missing or empty field 'data_manager_keys'")
+        raise BadRequestError("missing or empty field 'data_manager_keys'")
     datamanager_count = DataManagerFiles.objects.filter(key__in=data_manager_keys).count()
     if datamanager_count != len(data_manager_keys):
-        raise exceptions.BadRequestError(
+        raise BadRequestError(
             "One or more datamanager keys provided do not exist in local database. "
             f"Please create them before. DataManager keys: {data_manager_keys}"
         )

--- a/backend/api/views/exception_handler.py
+++ b/backend/api/views/exception_handler.py
@@ -3,8 +3,8 @@ from rest_framework import response
 from rest_framework import views
 
 import orchestrator.error
+from api.errors import ApiError
 from api.views import utils
-from substrapp import exceptions
 
 logger = structlog.get_logger(__name__)
 
@@ -17,7 +17,7 @@ def api_exception_handler(exc, context):
     if isinstance(exc, utils.ValidationExceptionError):
         return response.Response({"message": exc.data, "key": exc.key}, status=exc.st)
 
-    if isinstance(exc, exceptions.ApiError):
+    if isinstance(exc, ApiError):
         # emits a warning for all requests returning an API error response
         logger.warning("exception", class_name=exc.__class__.__name__, exception=exc)
         return exc.response()

--- a/backend/api/views/model.py
+++ b/backend/api/views/model.py
@@ -11,16 +11,16 @@ from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
 from rest_framework.viewsets import GenericViewSet
 
+from api.errors import AssetPermissionError
+from api.errors import BadRequestError
 from api.models import Model
 from api.serializers import ModelSerializer
 from api.views.filters_utils import ChoiceInFilter
-from api.views.utils import AssetPermissionError
 from api.views.utils import PermissionMixin
 from api.views.utils import get_channel_name
 from api.views.utils import if_true
 from libs.pagination import DefaultPageNumberPagination
 from organization.authentication import OrganizationUser
-from substrapp import exceptions
 from substrapp.models import Model as ModelFiles
 from substrapp.utils import get_owner
 
@@ -33,7 +33,7 @@ def validate_category(key, values):
             for value in values:
                 getattr(Model.Category, value)
         except AttributeError as e:
-            raise exceptions.BadRequestError(f"Wrong {key} value: {e}")
+            raise BadRequestError(f"Wrong {key} value: {e}")
     return key, values
 
 

--- a/backend/api/views/utils.py
+++ b/backend/api/views/utils.py
@@ -15,11 +15,11 @@ from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.viewsets import ViewSet
 
+from api.errors import AssetPermissionError
+from api.errors import BadRequestError
 from api.models import ComputeTask
 from organization.authentication import OrganizationUser
 from substrapp.clients import organization as organization_client
-from substrapp.exceptions import AssetPermissionError
-from substrapp.exceptions import BadRequestError
 from substrapp.storages.minio import MinioStorage
 from substrapp.utils import get_owner
 

--- a/backend/organization/tests/views/test_views_organization.py
+++ b/backend/organization/tests/views/test_views_organization.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from rest_framework.test import APITestCase
 
 from api.serializers import ChannelOrganizationSerializer as OrganizationRepSerializer
-from substrapp.tests.common import AuthenticatedClient
+from api.tests.common import AuthenticatedClient
 
 MEDIA_ROOT = "/tmp/unittests_views/"
 

--- a/backend/substrapp/exceptions.py
+++ b/backend/substrapp/exceptions.py
@@ -1,31 +1,3 @@
-from rest_framework import response
-from rest_framework import status
-
-
-class ApiError(Exception):
-    """Base error response returned by API."""
-
-    status = status.HTTP_500_INTERNAL_SERVER_ERROR
-    message = "Internal server error."
-
-    def __init__(self, message=None, data=None):
-        message = message or self.message
-
-        self.error = data or {}
-        self.error["message"] = message
-
-        super().__init__(message)
-
-    def response(self):
-        """Get HTTP Response from error instance."""
-        return response.Response(self.error, status=self.status)
-
-
-class BadRequestError(ApiError):
-    status = status.HTTP_400_BAD_REQUEST
-    message = "Bad request."
-
-
 class KubernetesError(Exception):
     pass
 
@@ -64,8 +36,3 @@ class IntegrityError(Exception):
 
 class ServerMediasNoSubdirError(Exception):
     """A supplied servermedias path didn't contain the expected subdir"""
-
-
-class AssetPermissionError(Exception):
-    def __init__(self, message="Unauthorized"):
-        super().__init__(self, message)

--- a/backend/substrapp/tests/common.py
+++ b/backend/substrapp/tests/common.py
@@ -1,17 +1,10 @@
-import base64
 import os
-import urllib
 from dataclasses import dataclass
-from http.cookies import SimpleCookie
 from io import BytesIO
 from io import StringIO
-from unittest import mock
 
-from django.contrib.auth.models import User
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from google.protobuf.json_format import MessageToDict
-from requests import auth
-from rest_framework.test import APIClient
 
 import orchestrator.algo_pb2 as algo_pb2
 from orchestrator import computetask_pb2 as computetask_pb2
@@ -28,12 +21,6 @@ from orchestrator.common_pb2 import ASSET_DATA_MANAGER
 from orchestrator.common_pb2 import ASSET_DATA_SAMPLE
 from orchestrator.common_pb2 import ASSET_MODEL
 from orchestrator.common_pb2 import ASSET_PERFORMANCE
-from organization.models import IncomingOrganization
-from users.models.user_channel import UserChannel
-
-# This function helper generate a basic authentication header with given credentials
-# Given username and password it returns "Basic GENERATED_TOKEN"
-from users.serializers import CustomTokenObtainPairSerializer
 
 _TASK_CATEGORY_NAME_TRAIN = computetask_pb2.ComputeTaskCategory.Name(computetask_pb2.TASK_TRAIN)
 _TASK_CATETGORY_NAME_COMPOSITE = computetask_pb2.ComputeTaskCategory.Name(computetask_pb2.TASK_COMPOSITE)
@@ -123,68 +110,9 @@ ALGO_OUTPUTS_PER_CATEGORY_DICT: dict[str, dict] = {
 }
 
 
-def generate_basic_auth_header(username, password):
-    return "Basic " + base64.b64encode(f"{username}:{password}".encode()).decode()
-
-
-def generate_jwt_auth_header(jwt):
-    return "JWT " + jwt
-
-
-class AuthenticatedClient(APIClient):
-    def __init__(self, enforce_csrf_checks=False, role=UserChannel.Role.USER, channel=None, **defaults):
-        super().__init__(enforce_csrf_checks, **defaults)
-        self.role = role
-        self.channel = channel
-
-    def request(self, **kwargs):
-        # create user
-        username = "substra"
-        password = "p@sswr0d44"
-        user, created = User.objects.get_or_create(username=username)
-        if created:
-            user.set_password(password)
-            user.save()
-            # for testing purpose most authentication are done without channel allowing to mock passing channel in
-            # header, this check is necessary to not break previous tests but irl a user cannot be created
-            # without a channel
-            if self.channel:
-                UserChannel.objects.create(user=user, channel_name=self.channel, role=self.role)
-
-        # simulate login
-        serializer = CustomTokenObtainPairSerializer(data={"username": username, "password": password})
-
-        serializer.is_valid()
-        data = serializer.validated_data
-        access_token = str(data.access_token)
-
-        # simulate right httpOnly cookie and Authorization jwt
-        jwt_auth_header = generate_jwt_auth_header(".".join(access_token.split(".")[0:2]))
-        self.credentials(HTTP_AUTHORIZATION=jwt_auth_header)
-        self.cookies = SimpleCookie({"signature": access_token.split(".")[2]})
-
-        return super().request(**kwargs)
-
-
-class AuthenticatedBackendClient(APIClient):
-    def request(self, **kwargs):
-
-        username = "MyTestOrg"
-        password = "p@sswr0d44"
-        try:
-            IncomingOrganization.objects.get(organization_id=username)
-        except IncomingOrganization.DoesNotExist:
-            IncomingOrganization.objects.create(organization_id=username, secret=password)
-
-        self.credentials(HTTP_AUTHORIZATION=auth._basic_auth_str(username, password))
-
-        return super().request(**kwargs)
-
-
 def get_temporary_text_file(contents, filename):
     """
     Creates a temporary text file
-
     :param contents: contents of the file
     :param filename: name of the file
     :type contents: str
@@ -421,21 +349,3 @@ class FakeRequest(object):
     def __init__(self, status, content):
         self.status_code = status
         self.content = content
-
-
-def encode_filter(params):
-    # We need to quote the params string because the filter function
-    # in the backend use the same  ':' url separator for key:value filtering object
-    return urllib.parse.quote(params)
-
-
-def internal_server_error_on_exception():
-    """Decorator factory to make the Django test client respond with '500 Internal Server Error'
-    when an unhandled exception occurs.
-
-    Once we update to Django 3, we can use the `raise_request_exception` parameter
-    of the test client: https://docs.djangoproject.com/en/3.2/topics/testing/tools/#making-requests.
-
-    Adapted from https://stackoverflow.com/a/62720158.
-    """
-    return mock.patch("django.test.client.Client.store_exc_info", mock.Mock())

--- a/backend/users/tests/test_user.py
+++ b/backend/users/tests/test_user.py
@@ -5,7 +5,7 @@ from django.urls.base import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from substrapp.tests.common import AuthenticatedClient
+from api.tests.common import AuthenticatedClient
 from users.models.user_channel import UserChannel
 
 


### PR DESCRIPTION
After `substrapp` views being moved to `api` (see https://github.com/Substra/substra-backend/pull/441), some utils, only used by `api`, remain in `substrapp` so this PR move them.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202963105406684