### PR TITLE
ci: run workflows only on tip of branches

### DIFF
--- a/.github/workflows/container-image-backend.yml
+++ b/.github/workflows/container-image-backend.yml
@@ -14,6 +14,10 @@ on:
       - 'backend/**'
       - '.github/workflows/container-image-backend.yml'
 
+concurrency: 
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/container-image-metrics.yml
+++ b/.github/workflows/container-image-metrics.yml
@@ -13,6 +13,11 @@ on:
       - 'docker/metrics-exporter/*'
       - 'metrics-exporter/**'
       - '.github/workflows/gcr-metrics.yml'
+
+concurrency: 
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -10,6 +10,10 @@ on:
     paths:
       - "docker/**"
 
+concurrency: 
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint Dockerfile

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -12,6 +12,10 @@ on:
     paths:
       - "charts/**"
 
+concurrency: 
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Tests

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   lint_and_tests:
     name: Lint and tests


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add a concurrency setting to limit the workflow runs to one per branch.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Reduce the amount of workflows running on our repo. This is similar to what was done in the orchestrator repo (https://github.com/Substra/orchestrator/commit/aef84dd54f8d4267f070358c347c74791a7ce569)