### PR TITLE
refactor: orchestrator client return info object

### DIFF
--- a/backend/api/tests/views/test_views_info.py
+++ b/backend/api/tests/views/test_views_info.py
@@ -7,6 +7,7 @@ from rest_framework.test import APITestCase
 
 from api.tests.common import AuthenticatedClient
 from orchestrator.client import OrchestratorClient
+from orchestrator.resources import OrchestratorVersion
 
 
 @override_settings(LEDGER_CHANNELS={"mychannel": {"chaincode": {"name": "mycc"}, "model_export_enabled": True}})
@@ -32,7 +33,7 @@ class InfoViewTests(APITestCase):
         client = AuthenticatedClient()
 
         with mock.patch.object(
-            OrchestratorClient, "query_version", return_value={"orchestrator": "foo", "chaincode": "bar"}
+            OrchestratorClient, "query_version", return_value=OrchestratorVersion(server="foo", chaincode="bar")
         ):
             response = client.get(self.url, **self.extra)
 

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -52,7 +52,7 @@ class Info(APIView):
             channel_name = get_channel_name(request)
             channel = settings.LEDGER_CHANNELS[channel_name]
 
-            orchestrator_versions = {}
+            orchestrator_versions = None
 
             if not settings.ISOLATED:
                 with get_orchestrator_client(channel_name) as client:
@@ -60,15 +60,15 @@ class Info(APIView):
 
             res["channel"] = channel_name
             res["version"] = settings.BACKEND_VERSION
-            res["orchestrator_version"] = orchestrator_versions.get("orchestrator")
+            res["orchestrator_version"] = orchestrator_versions.server if orchestrator_versions is not None else None
             res["config"]["model_export_enabled"] = channel["model_export_enabled"]
 
             res["user"] = request.user.get_username()
             if hasattr(request.user, "channel"):
                 res["user_role"] = request.user.channel.role
 
-            if orchestrator_versions.get("chaincode"):
-                res["chaincode_version"] = orchestrator_versions.get("chaincode")
+            if orchestrator_versions and orchestrator_versions.chaincode:
+                res["chaincode_version"] = orchestrator_versions.chaincode
 
         return ApiResponse(res)
 

--- a/backend/orchestrator/client.py
+++ b/backend/orchestrator/client.py
@@ -8,7 +8,6 @@ import structlog
 from django.conf import settings
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.timestamp_pb2 import Timestamp
-from orchestrator.resources import OrchestratorVersion
 
 import orchestrator.algo_pb2 as algo_pb2
 import orchestrator.common_pb2 as common_pb2
@@ -40,6 +39,7 @@ from orchestrator.resources import ComputePlan
 from orchestrator.resources import ComputePlanStatus
 from orchestrator.resources import ComputeTask
 from orchestrator.resources import ComputeTaskInputAsset
+from orchestrator.resources import OrchestratorVersion
 
 logger = structlog.get_logger(__name__)
 

--- a/backend/orchestrator/client.py
+++ b/backend/orchestrator/client.py
@@ -8,6 +8,7 @@ import structlog
 from django.conf import settings
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.timestamp_pb2 import Timestamp
+from orchestrator.resources import OrchestratorVersion
 
 import orchestrator.algo_pb2 as algo_pb2
 import orchestrator.common_pb2 as common_pb2
@@ -530,15 +531,12 @@ class OrchestratorClient:
 
         return (MessageToDict(event, **CONVERT_SETTINGS) for event in events_stream)
 
-    def query_version(
-        self,
-    ):
+    def query_version(self) -> OrchestratorVersion:
         data = self._info_client.QueryVersion(
             info_pb2.QueryVersionParam(),
             metadata=self._metadata,
         )
-        data = MessageToDict(data, **CONVERT_SETTINGS)
-        return data
+        return OrchestratorVersion.from_grpc(data)
 
     def __enter__(self):
         return self

--- a/backend/orchestrator/resources.py
+++ b/backend/orchestrator/resources.py
@@ -5,7 +5,6 @@ from typing import Optional
 from typing import Union
 
 import pydantic
-from orchestrator import info_pb2
 
 from orchestrator import algo_pb2
 from orchestrator import common_pb2
@@ -13,6 +12,7 @@ from orchestrator import computeplan_pb2
 from orchestrator import computetask_pb2
 from orchestrator import datamanager_pb2
 from orchestrator import datasample_pb2
+from orchestrator import info_pb2
 from orchestrator import model_pb2
 
 

--- a/backend/orchestrator/resources.py
+++ b/backend/orchestrator/resources.py
@@ -5,6 +5,7 @@ from typing import Optional
 from typing import Union
 
 import pydantic
+from orchestrator import info_pb2
 
 from orchestrator import algo_pb2
 from orchestrator import common_pb2
@@ -344,3 +345,12 @@ class InvalidInputAsset(Exception):
     def __init__(self, actual: AssetKind, expected: AssetKind):
         message = f"Invalid asset kind, expected {expected} but have {actual}"
         super().__init__(message)
+
+
+class OrchestratorVersion(pydantic.BaseModel):
+    server: str
+    chaincode: str
+
+    @classmethod
+    def from_grpc(cls, orc_version: info_pb2.QueryVersionResponse) -> OrchestratorVersion:
+        return cls(server=orc_version.orchestrator, chaincode=orc_version.chaincode)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Create a new object `OrchestratorVersion`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is the same as the change done in previous PRs to switch the outputs from the orchestrator from a dict to an object.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I tested the change locally by accessing `/info` and everything seems to work.