### PR TITLE
chore: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Description
+
+<!-- Please reference issue if any. -->
+
+<!-- Please include a summary of your changes. -->
+
+## How has this been tested?
+
+<!-- Please describe the tests that you ran to verify your changes.  -->
+
+## Checklist
+
+- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
+- [ ] documentation was updated


### PR DESCRIPTION
## Rationale

This will help improve content of PR descriptions.
The template is the same than for the [orchestrator](https://github.com/Substra/orchestrator/).