### PR TITLE
feat: stop cleaning up models using delete_intermediary_models

### DIFF
--- a/backend/substrapp/events/handler_compute_engine.py
+++ b/backend/substrapp/events/handler_compute_engine.py
@@ -4,8 +4,8 @@ from django.conf import settings
 
 import orchestrator
 from substrapp.tasks.tasks_outputs import queue_disable_transient_outputs
+from substrapp.tasks.tasks_remove_intermediary_models import queue_remove_intermediary_model_from_db
 from substrapp.tasks.tasks_remove_intermediary_models import queue_remove_intermediary_models_from_buffer
-from substrapp.tasks.tasks_remove_intermediary_models import queue_remove_intermediary_models_from_db_new
 
 _MY_ORGANIZATION: str = settings.LEDGER_MSP_ID
 
@@ -68,4 +68,4 @@ def handle_finished_tasks(orc_client: orchestrator.Client, channel_name: str, ta
 def handle_disabled_model(channel_name: str, model: orchestrator.Model) -> None:
     queue_remove_intermediary_models_from_buffer(model.key)
     if model.owner == _MY_ORGANIZATION:
-        queue_remove_intermediary_models_from_db_new(channel_name, model.key)
+        queue_remove_intermediary_model_from_db(channel_name, model.key)

--- a/backend/substrapp/events/tests/test_handler_compute_engine.py
+++ b/backend/substrapp/events/tests/test_handler_compute_engine.py
@@ -170,7 +170,7 @@ class TestHandleDisabledModel:
             "substrapp.events.handler_compute_engine.queue_remove_intermediary_models_from_buffer"
         )
         m_queue_remove_intermediary_model_db = mocker.patch(
-            "substrapp.events.handler_compute_engine.queue_remove_intermediary_models_from_db_new"
+            "substrapp.events.handler_compute_engine.queue_remove_intermediary_model_from_db"
         )
         model = orc_mock.ModelFactory(owner="my_worker")
         handler_compute_engine._MY_ORGANIZATION = "my_worker"

--- a/backend/substrapp/tasks/__init__.py
+++ b/backend/substrapp/tasks/__init__.py
@@ -3,17 +3,15 @@ from substrapp.tasks.tasks_compute_task import compute_task
 from substrapp.tasks.tasks_docker_registry import clean_old_images_task
 from substrapp.tasks.tasks_docker_registry import docker_registry_garbage_collector_task
 from substrapp.tasks.tasks_outputs import remove_transient_outputs_from_orc
+from substrapp.tasks.tasks_remove_intermediary_models import remove_intermediary_model_from_db
 from substrapp.tasks.tasks_remove_intermediary_models import remove_intermediary_models_from_buffer
-from substrapp.tasks.tasks_remove_intermediary_models import remove_intermediary_models_from_db
-from substrapp.tasks.tasks_remove_intermediary_models import remove_intermediary_models_from_db_new
 
 __all__ = [
     "delete_cp_pod_and_dirs_and_optionally_images",
     "compute_task",
     "clean_old_images_task",
     "docker_registry_garbage_collector_task",
-    "remove_intermediary_models_from_db",
     "remove_intermediary_models_from_buffer",
     "remove_transient_outputs_from_orc",
-    "remove_intermediary_models_from_db_new",
+    "remove_intermediary_model_from_db",
 ]

--- a/backend/substrapp/tasks/tasks_remove_intermediary_models.py
+++ b/backend/substrapp/tasks/tasks_remove_intermediary_models.py
@@ -5,39 +5,8 @@ from substrapp.compute_tasks.asset_buffer import delete_models_from_buffer
 from substrapp.compute_tasks.datastore import Datastore
 from substrapp.compute_tasks.datastore import DatastoreError
 from substrapp.compute_tasks.datastore import get_datastore
-from substrapp.orchestrator import get_orchestrator_client
 
 logger = structlog.get_logger(__name__)
-
-
-def queue_remove_intermediary_models_from_db(channel_name: str, model_keys: list[str]) -> None:
-    # the task can run on any worker
-    from substrapp.task_routing import get_generic_worker_queue
-
-    worker_queue = get_generic_worker_queue()
-
-    remove_intermediary_models_from_db.apply_async((channel_name, model_keys), queue=worker_queue)
-
-
-@app.task(ignore_result=False)
-def remove_intermediary_models_from_db(channel_name: str, model_keys: list[str]) -> None:
-    """
-    Remove model from db.
-    Disable model in orchestrator.
-    """
-    from substrapp.models import Model
-
-    models = Model.objects.filter(key__in=model_keys)
-    filtered_model_keys = [str(model.key) for model in models]
-    models.delete()
-
-    if filtered_model_keys:
-
-        with get_orchestrator_client(channel_name) as client:
-            for model_key in filtered_model_keys:
-                client.disable_model(model_key)
-
-        logger.info("Delete intermediary models", model_keys=", ".join(filtered_model_keys))
 
 
 def queue_remove_intermediary_models_from_buffer(model_key: str) -> None:
@@ -56,16 +25,16 @@ def remove_intermediary_models_from_buffer(model_key: str) -> None:
     delete_models_from_buffer([model_key])
 
 
-def queue_remove_intermediary_models_from_db_new(channel_name: str, model_key: str) -> None:
+def queue_remove_intermediary_model_from_db(channel_name: str, model_key: str) -> None:
     from substrapp.task_routing import get_generic_worker_queue
 
     worker_queue = get_generic_worker_queue()
 
-    remove_intermediary_models_from_db_new.apply_async((channel_name, model_key), queue=worker_queue)
+    remove_intermediary_model_from_db.apply_async((channel_name, model_key), queue=worker_queue)
 
 
 @app.task(ignore_result=False)
-def remove_intermediary_models_from_db_new(channel_name: str, model_key: str) -> None:
+def remove_intermediary_model_from_db(channel_name: str, model_key: str) -> None:
     datastore = get_datastore(channel_name)
     _delete_intermediary_model_from_db(datastore, model_key)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Remove the code that was used to cleanup models in the compute engine.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `delete_intermediary_models` flag was removed from the API so it will always be `False` in the future, making this code useless.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

e2e tests.
Result:
```
============ 110 passed, 7 skipped, 7 warnings in 558.47s (0:09:18) ============
```