### PR TITLE
feat: add output identifier in compute plan perf api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BREAKING: model categories
 
+### Added
+
+- output identifier add in metric response object in `compute_plan perf` view.
+
 ## [0.31.0] 2022-09-26
 
 ### Changed

--- a/backend/api/serializers/performance.py
+++ b/backend/api/serializers/performance.py
@@ -42,8 +42,6 @@ class _PerformanceMetricSerializer(serializers.ModelSerializer):
         model = Algo
         fields = ["key", "name", "output_identifier"]
 
-    # TODO: Now we have to match output only by algo key, once the link asset<->output is implemented in localrep the
-    # relation performance<->output_identifier will be more starightforward and unambiguous.
     def get_output_identifier(self, obj):
         try:
             performance_output = AlgoOutput.objects.get(

--- a/backend/api/serializers/performance.py
+++ b/backend/api/serializers/performance.py
@@ -1,9 +1,11 @@
 from rest_framework import serializers
 
 from api.models import Algo
+from api.models import AlgoOutput
 from api.models import ComputeTask
 from api.models import Performance
 from api.serializers.utils import SafeSerializerMixin
+from orchestrator import common_pb2
 
 
 class PerformanceSerializer(serializers.ModelSerializer, SafeSerializerMixin):
@@ -34,9 +36,23 @@ class PerformanceSerializer(serializers.ModelSerializer, SafeSerializerMixin):
 
 
 class _PerformanceMetricSerializer(serializers.ModelSerializer):
+    output_identifier = serializers.SerializerMethodField()
+
     class Meta:
         model = Algo
-        fields = ["key", "name"]
+        fields = ["key", "name", "output_identifier"]
+
+    # TODO: Now we have to match output only by algo key, once the link asset<->output is implemented in localrep the
+    # relation performance<->output_identifier will be more starightforward and unambiguous.
+    def get_output_identifier(self, obj):
+        try:
+            performance_output = AlgoOutput.objects.get(
+                algo_id=obj.key, kind=common_pb2.AssetKind.Name(common_pb2.ASSET_PERFORMANCE)
+            )
+        except (AlgoOutput.MultipleObjectsReturned, AlgoOutput.DoesNotExist) as e:
+            raise Exception(f"Couldn't associate an output identifier to performance for algo '{obj.key}', error : {e}")
+
+        return performance_output.identifier
 
 
 class _PerformanceComputeTaskSerializer(serializers.ModelSerializer):

--- a/backend/api/tests/views/test_views_performance.py
+++ b/backend/api/tests/views/test_views_performance.py
@@ -14,7 +14,7 @@ from api.models import ComputeTask
 from api.models import Performance
 from api.tests import asset_factory as factory
 from api.tests.common import AuthenticatedClient
-from ..common import InputIdentifiers
+from substrapp.tests.common import InputIdentifiers
 
 MEDIA_ROOT = tempfile.mkdtemp()
 

--- a/backend/api/tests/views/test_views_performance.py
+++ b/backend/api/tests/views/test_views_performance.py
@@ -14,6 +14,7 @@ from api.models import ComputeTask
 from api.models import Performance
 from api.tests import asset_factory as factory
 from api.tests.common import AuthenticatedClient
+from ..common import InputIdentifiers
 
 MEDIA_ROOT = tempfile.mkdtemp()
 
@@ -69,6 +70,7 @@ class CPPerformanceViewTests(APITestCase):
                 "metric": {
                     "key": str(self.metric.key),
                     "name": self.metric.name,
+                    "output_identifier": InputIdentifiers.PERFORMANCE,
                 },
                 "perf": self.performances[0].value,
             },
@@ -85,6 +87,7 @@ class CPPerformanceViewTests(APITestCase):
                 "metric": {
                     "key": str(self.metric.key),
                     "name": self.metric.name,
+                    "output_identifier": InputIdentifiers.PERFORMANCE,
                 },
                 "perf": self.performances[1].value,
             },
@@ -101,6 +104,7 @@ class CPPerformanceViewTests(APITestCase):
                 "metric": {
                     "key": str(self.metric.key),
                     "name": self.metric.name,
+                    "output_identifier": InputIdentifiers.PERFORMANCE,
                 },
                 "perf": self.performances[2].value,
             },


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->
Related to [asana task](https://app.asana.com/0/1200346939311555/1202721024997169)

Before Generic task, on frontend side performance series were build based on `metric key`. Now the equivalent unique key to identify a perf is `(task_key, algo_key, output_identifier)`. The output identifier should now be returned by compute plan perf endpoint.

<!-- Please include a summary of your changes. -->
This PR adds the output_identifier to metric field.
New api response : 
```javascript
        {
            "compute_task": {
                "key": "d4fea647-f799-436e-9181-3af75a861cec",
                "data_manager_key": "e7ccd2d4-b48d-4c3b-aa64-4cfbb42051d4",
                "algo_key": "8984a47c-7c34-4d54-8936-f9839c64acdb",
                "rank": 2,
                "round_idx": null,
                "data_samples": [
                    "f7beeee6-ce51-4f67-99cd-fa5237b73c86"
                ],
                "worker": "MyOrg1MSP"
            },
            "metric": {
                "key": "8984a47c-7c34-4d54-8936-f9839c64acdb",
                "name": "4a00d815120a4a7c90887d2978ee4117_global - Algo 0",
                "output_identifier": "performance"
            },
            "perf": 2.0
        }
    ],
    "compute_plan_statistics": {
        "compute_tasks_distinct_ranks": [
            1,
            2
        ],
        "compute_tasks_distinct_rounds": []
    }
```

## How has this been tested?
API was tested deploying isolated backend using data dump from previous local e2e run.

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
