### PR TITLE
test: provide algo inputs outputs to factory

### DIFF
--- a/backend/api/tests/asset_factory.py
+++ b/backend/api/tests/asset_factory.py
@@ -3,7 +3,10 @@ Utility module to create fixtures.
 
 Basic example:
 
->>> algo = create_algo(category=Algo.Category.ALGO_SIMPLE)
+>>> algo = create_algo(
+...     inputs=factory.build_algo_inputs(["datasamples", "opener", "model"]),
+...     outputs=factory.build_algo_outputs(["model"]),
+... )
 >>> data_manager = create_datamanager()
 >>> data_sample = create_datasample([data_manager])
 >>> compute_plan = create_computeplan(status=ComputePlan.Status.PLAN_STATUS_DONE)
@@ -11,24 +14,44 @@ Basic example:
 >>> train_task = create_computetask(
 ...     compute_plan,
 ...     algo,
+...     inputs=factory.build_computetask_inputs(
+...         algo,
+...         {
+...             "opener": [data_manager.key],
+...             "datasamples": [data_sample.key],
+...         },
+...     ),
+...     outputs=factory.build_computetask_outputs(algo),
 ...     data_manager=data_manager,
 ...     data_samples=[data_sample.key],
 ...     category=ComputeTask.Category.TASK_TRAIN,
 ...     status=ComputeTask.Status.STATUS_DONE,
 ... )
->>> model = create_model(train_task)
+>>> model = create_model(train_task, identifier="model")
 
->>> metric = create_algo(category=Algo.Category.ALGO_METRIC)
+>>> metric = create_algo(
+...     inputs=factory.build_algo_inputs(["datasamples", "opener", "model"]),
+...     outputs=factory.build_algo_outputs(["performance"]),
+... )
 >>> test_task = create_computetask(
 ...     compute_plan,
 ...     metric,
+...     inputs=factory.build_computetask_inputs(
+...         metric,
+...         {
+...             "opener": [data_manager.key],
+...             "datasamples": [data_sample.key],
+...             "model": [train_task.key],
+...         },
+...     ),
+...     outputs=factory.build_computetask_outputs(metric),
 ...     data_manager=data_manager,
 ...     data_samples=[data_sample],
 ...     parent_tasks=[train_task.key],
 ...     category=ComputeTask.Category.TASK_TEST,
 ...     status=ComputeTask.Status.STATUS_DONE,
 ... )
->>> performance = create_performance(test_task, metric)
+>>> performance = create_performance(test_task, metric, identifier="performance")
 
 Customized example:
 

--- a/backend/api/tests/views/test_views_computetask.py
+++ b/backend/api/tests/views/test_views_computetask.py
@@ -202,11 +202,11 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
         }
         model_input = {
             "identifier": "model",
-            "asset_key": str(self.done_train_task.key),
-            "parent_task_key": None,
-            "parent_task_output_identifier": None,
+            "asset_key": None,
+            "parent_task_key": str(self.done_train_task.key),
+            "parent_task_output_identifier": "model",
             # FIXME: "addressable": self.train_model_data["address"],
-            # FIXME: "permissions": self.train_model_data["permissions"],
+            "permissions": self.train_model_data["permissions"],
         }
         shared_input = {**model_input}
         shared_input["identifier"] = "shared"

--- a/backend/api/tests/views/test_views_computetask.py
+++ b/backend/api/tests/views/test_views_computetask.py
@@ -1,4 +1,4 @@
-import json
+import copy
 import logging
 import os
 import shutil
@@ -42,25 +42,49 @@ class ComputeTaskViewTests(APITestCase):
         self.previous_level = self.logger.getEffectiveLevel()
         self.logger.setLevel(logging.ERROR)
 
-        self.algos = {
-            category: factory.create_algo(category=category)
-            for category in [
-                Algo.Category.ALGO_SIMPLE,
-                Algo.Category.ALGO_COMPOSITE,
-                Algo.Category.ALGO_AGGREGATE,
-                Algo.Category.ALGO_PREDICT,
-                Algo.Category.ALGO_METRIC,
-            ]
-        }
+        self.simple_algo = factory.create_algo(
+            inputs=factory.build_algo_inputs(["datasamples", "opener", "model"]),
+            outputs=factory.build_algo_outputs(["model"]),
+            category=Algo.Category.ALGO_SIMPLE,
+            name="simple algo",
+        )
+        self.aggregate_algo = factory.create_algo(
+            inputs=factory.build_algo_inputs(["model"]),
+            outputs=factory.build_algo_outputs(["model"]),
+            category=Algo.Category.ALGO_AGGREGATE,
+            name="aggregate",
+        )
+        self.composite_algo = factory.create_algo(
+            inputs=factory.build_algo_inputs(["datasamples", "opener", "local", "shared"]),
+            outputs=factory.build_algo_outputs(["local", "shared"]),
+            category=Algo.Category.ALGO_COMPOSITE,
+            name="composite",
+        )
+        self.predict_algo = factory.create_algo(
+            inputs=factory.build_algo_inputs(["datasamples", "opener", "model", "shared"]),
+            outputs=factory.build_algo_outputs(["predictions"]),
+            category=Algo.Category.ALGO_PREDICT,
+            name="predict",
+        )
+        self.metric_algo = factory.create_algo(
+            inputs=factory.build_algo_inputs(["datasamples", "opener", "predictions"]),
+            outputs=factory.build_algo_outputs(["performance"]),
+            category=Algo.Category.ALGO_METRIC,
+            name="metric",
+        )
         self.data_manager = factory.create_datamanager()
         self.data_sample = factory.create_datasample([self.data_manager])
         self.compute_plan = factory.create_computeplan()
 
         self.compute_tasks = {}
-        for category in (
-            ComputeTask.Category.TASK_TRAIN,
-            ComputeTask.Category.TASK_TEST,
-            ComputeTask.Category.TASK_COMPOSITE,
+        input_keys = {
+            "opener": [self.data_manager.key],
+            "datasamples": [self.data_sample.key],
+        }
+        for algo, category in (
+            (self.simple_algo, ComputeTask.Category.TASK_TRAIN),
+            (self.metric_algo, ComputeTask.Category.TASK_TEST),
+            (self.composite_algo, ComputeTask.Category.TASK_COMPOSITE),
         ):
             self.compute_tasks[category] = {}
             for _status in (
@@ -76,7 +100,9 @@ class ComputeTaskViewTests(APITestCase):
                 )
                 self.compute_tasks[category][_status] = factory.create_computetask(
                     self.compute_plan,
-                    self.algos[factory.TASK_CATEGORY_TO_ALGO_CATEGORY[category]],
+                    algo,
+                    inputs=factory.build_computetask_inputs(algo, input_keys),
+                    outputs=factory.build_computetask_outputs(algo),
                     data_manager=self.data_manager,
                     data_samples=[self.data_sample.key],
                     category=category,
@@ -84,30 +110,22 @@ class ComputeTaskViewTests(APITestCase):
                     error_type=error_type,
                 )
 
-        done_train_task = self.compute_tasks[ComputeTask.Category.TASK_TRAIN][ComputeTask.Status.STATUS_DONE]
-        self.train_model = factory.create_model(done_train_task, identifier="model")
+        self.done_train_task = self.compute_tasks[ComputeTask.Category.TASK_TRAIN][ComputeTask.Status.STATUS_DONE]
+        self.train_model = factory.create_model(self.done_train_task, identifier="model")
 
         done_composite_task = self.compute_tasks[ComputeTask.Category.TASK_COMPOSITE][ComputeTask.Status.STATUS_DONE]
         self.local_model = factory.create_model(done_composite_task, identifier="local")
         self.shared_model = factory.create_model(done_composite_task, identifier="shared")
 
-        done_failed_task = self.compute_tasks[ComputeTask.Category.TASK_TEST][ComputeTask.Status.STATUS_DONE]
-        self.performance = factory.create_performance(done_failed_task, self.algos[Algo.Category.ALGO_METRIC])
+        done_test_task = self.compute_tasks[ComputeTask.Category.TASK_TEST][ComputeTask.Status.STATUS_DONE]
+        self.performance = factory.create_performance(done_test_task, self.metric_algo)
 
         # we don't explicitly serialize relationships as this test module is focused on computetask
-
-        self.algo_data = {
-            # use JSON serializer to convert OrderDicts to dicts, making diffs easier to read
-            category: json.loads(json.dumps(AlgoSerializer(instance=self.algos[category]).data))
-            for category in [
-                Algo.Category.ALGO_SIMPLE,
-                Algo.Category.ALGO_COMPOSITE,
-                Algo.Category.ALGO_AGGREGATE,
-                Algo.Category.ALGO_PREDICT,
-                Algo.Category.ALGO_METRIC,
-            ]
-        }
-
+        self.simple_algo_data = AlgoSerializer(instance=self.simple_algo).data
+        self.aggregate_algo_data = AlgoSerializer(instance=self.aggregate_algo).data
+        self.composite_algo_data = AlgoSerializer(instance=self.composite_algo).data
+        self.predict_algo_data = AlgoSerializer(instance=self.predict_algo).data
+        self.metric_algo_data = AlgoSerializer(instance=self.metric_algo).data
         self.data_manager_data = DataManagerSerializer(instance=self.data_manager).data
         self.train_model_data = ModelSerializer(instance=self.train_model).data
         self.local_model_data = ModelSerializer(instance=self.local_model).data
@@ -123,8 +141,6 @@ class ComputeTaskViewTests(APITestCase):
     LEDGER_CHANNELS={"mychannel": {"chaincode": {"name": "mycc"}, "model_export_enabled": True}},
 )
 class TaskBulkCreateViewTests(ComputeTaskViewTests):
-    _parent_task_key = str(uuid.uuid4())
-
     def test_task_bulk_create(self):
         def mock_register_compute_task(orc_request):
             """Build orchestrator register response from request data."""
@@ -138,7 +154,7 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
                         "key": in_data["algo_key"],
                     },
                     "compute_plan_key": in_data["compute_plan_key"],
-                    "parent_task_keys": [self._parent_task_key],
+                    "parent_task_keys": [],
                     "rank": 0,
                     "status": "STATUS_WAITING",
                     "owner": "MyOrg1MSP",
@@ -169,17 +185,43 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
         aggregate_task_key = str(uuid.uuid4())
         test_task_key = str(uuid.uuid4())
         predict_task_key = str(uuid.uuid4())
-        done_train_task = self.compute_tasks[ComputeTask.Category.TASK_TRAIN][ComputeTask.Status.STATUS_DONE]
+        datasamples_input = {
+            "identifier": "datasamples",
+            "asset_key": str(self.data_sample.key),
+            "parent_task_key": None,
+            "parent_task_output_identifier": None,
+        }
+        opener_input = {
+            "identifier": "opener",
+            "asset_key": str(self.data_manager.key),
+            "parent_task_key": None,
+            "parent_task_output_identifier": None,
+            # FIXME: "addressable": self.data_manager_data["opener"],
+            "addressable": None,
+            "permissions": self.data_manager_data["permissions"],
+        }
+        model_input = {
+            "identifier": "model",
+            "asset_key": str(self.done_train_task.key),
+            "parent_task_key": None,
+            "parent_task_output_identifier": None,
+            # FIXME: "addressable": self.train_model_data["address"],
+            # FIXME: "permissions": self.train_model_data["permissions"],
+        }
+        shared_input = {**model_input}
+        shared_input["identifier"] = "shared"
+        predictions_input = {**model_input}
+        predictions_input["identifier"] = "predictions"
         data = {
             "tasks": [
                 {
                     "compute_plan_key": self.compute_plan.key,
                     "category": "TASK_TRAIN",
                     "key": train_task_key,
-                    "algo_key": self.algos[Algo.Category.ALGO_SIMPLE].key,
+                    "algo_key": self.simple_algo.key,
                     "data_manager_key": self.data_manager.key,
                     "train_data_sample_keys": [self.data_sample.key],
-                    "inputs": _build_inputs(ComputeTask.Category.TASK_TRAIN),
+                    "inputs": [datasamples_input, opener_input, model_input],
                     "outputs": {
                         "model": {"permissions": {"public": False, "authorized_ids": ["MyOrg1MSP"]}, "transient": True},
                     },
@@ -188,10 +230,10 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
                     "compute_plan_key": self.compute_plan.key,
                     "category": "TASK_AGGREGATE",
                     "key": aggregate_task_key,
-                    "in_models_keys": [train_task_key, done_train_task.key],
-                    "algo_key": self.algos[Algo.Category.ALGO_AGGREGATE].key,
+                    "in_models_keys": [train_task_key, self.done_train_task.key],
+                    "algo_key": self.aggregate_algo.key,
                     "worker": "MyOrg1MSP",
-                    "inputs": _build_inputs(ComputeTask.Category.TASK_AGGREGATE),
+                    "inputs": [model_input],
                     "outputs": {
                         "model": {"permissions": {"public": False, "authorized_ids": ["MyOrg1MSP"]}},
                     },
@@ -201,10 +243,10 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
                     "category": "TASK_PREDICT",
                     "traintuple_key": train_task_key,
                     "key": predict_task_key,
-                    "algo_key": self.algos[Algo.Category.ALGO_PREDICT].key,
+                    "algo_key": self.predict_algo.key,
                     "data_manager_key": self.data_manager.key,
                     "test_data_sample_keys": [self.data_sample.key],
-                    "inputs": _build_inputs(ComputeTask.Category.TASK_PREDICT),
+                    "inputs": [datasamples_input, opener_input, model_input, shared_input],
                     "outputs": {
                         "predictions": {"permissions": {"public": False, "authorized_ids": ["MyOrg1MSP"]}},
                     },
@@ -214,10 +256,10 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
                     "category": "TASK_TEST",
                     "key": test_task_key,
                     "predicttuple_key": predict_task_key,
-                    "algo_key": self.algos[Algo.Category.ALGO_METRIC].key,
+                    "algo_key": self.metric_algo.key,
                     "data_manager_key": self.data_manager.key,
                     "test_data_sample_keys": [self.data_sample.key],
-                    "inputs": _build_inputs(ComputeTask.Category.TASK_TEST),
+                    "inputs": [datasamples_input, opener_input, predictions_input],
                     "outputs": {
                         "performance": {"permissions": {"public": True, "authorized_ids": []}},
                     },
@@ -228,7 +270,7 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
         expected_response = [
             {
                 "key": train_task_key,
-                "algo": self.algo_data[Algo.Category.ALGO_SIMPLE],
+                "algo": self.simple_algo_data,
                 "category": "TASK_TRAIN",
                 "compute_plan_key": str(self.compute_plan.key),
                 "creation_date": "2021-11-04T13:54:09.882662Z",
@@ -242,7 +284,7 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
                     TAG_KEY: "",
                 },
                 "owner": "MyOrg1MSP",
-                "parent_task_keys": [self._parent_task_key],
+                "parent_task_keys": [],
                 "rank": 0,
                 "start_date": None,
                 "status": "STATUS_WAITING",
@@ -257,7 +299,7 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
                     "models": None,
                 },
                 "worker": "MyOrg1MSP",
-                "inputs": _build_inputs(ComputeTask.Category.TASK_TRAIN),
+                "inputs": [datasamples_input, opener_input, model_input],
                 "outputs": {
                     "model": {
                         "permissions": {
@@ -271,7 +313,7 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
             },
             {
                 "key": aggregate_task_key,
-                "algo": self.algo_data[Algo.Category.ALGO_AGGREGATE],
+                "algo": self.aggregate_algo_data,
                 "category": "TASK_AGGREGATE",
                 "compute_plan_key": str(self.compute_plan.key),
                 "creation_date": "2021-11-04T13:54:09.882662Z",
@@ -285,7 +327,7 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
                     TAG_KEY: "",
                 },
                 "owner": "MyOrg1MSP",
-                "parent_task_keys": [self._parent_task_key],
+                "parent_task_keys": [],
                 "rank": 0,
                 "start_date": None,
                 "status": "STATUS_WAITING",
@@ -298,7 +340,7 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
                     "models": None,
                 },
                 "worker": "MyOrg1MSP",
-                "inputs": _build_inputs(ComputeTask.Category.TASK_AGGREGATE),
+                "inputs": [model_input],
                 "outputs": {
                     "model": {
                         "permissions": {
@@ -312,7 +354,7 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
             },
             {
                 "key": predict_task_key,
-                "algo": self.algo_data[Algo.Category.ALGO_PREDICT],
+                "algo": self.predict_algo_data,
                 "category": "TASK_PREDICT",
                 "compute_plan_key": str(self.compute_plan.key),
                 "creation_date": "2021-11-04T13:54:09.882662Z",
@@ -326,7 +368,7 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
                     TAG_KEY: "",
                 },
                 "owner": "MyOrg1MSP",
-                "parent_task_keys": [self._parent_task_key],
+                "parent_task_keys": [],
                 "rank": 0,
                 "start_date": None,
                 "status": "STATUS_WAITING",
@@ -341,7 +383,7 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
                     "models": None,
                 },
                 "worker": "MyOrg1MSP",
-                "inputs": _build_inputs(ComputeTask.Category.TASK_PREDICT),
+                "inputs": [datasamples_input, opener_input, model_input, shared_input],
                 "outputs": {
                     "predictions": {
                         "permissions": {
@@ -355,7 +397,7 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
             },
             {
                 "key": test_task_key,
-                "algo": self.algo_data[Algo.Category.ALGO_METRIC],
+                "algo": self.metric_algo_data,
                 "category": "TASK_TEST",
                 "compute_plan_key": str(self.compute_plan.key),
                 "creation_date": "2021-11-04T13:54:09.882662Z",
@@ -369,7 +411,7 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
                     TAG_KEY: "",
                 },
                 "owner": "MyOrg1MSP",
-                "parent_task_keys": [self._parent_task_key],
+                "parent_task_keys": [],
                 "rank": 0,
                 "start_date": None,
                 "status": "STATUS_WAITING",
@@ -380,7 +422,7 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
                     "perfs": None,
                 },
                 "worker": "MyOrg1MSP",
-                "inputs": _build_inputs(ComputeTask.Category.TASK_TEST),
+                "inputs": [datasamples_input, opener_input, predictions_input],
                 "outputs": {
                     "performance": {
                         "permissions": {
@@ -393,7 +435,7 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
                 },
             },
         ]
-        self.maxDiff = None
+
         url = reverse("api:task_bulk_create")
         with mock.patch.object(OrchestratorClient, "register_tasks", side_effect=mock_register_compute_task):
             response = self.client.post(url, data=data, format="json", **self.extra)
@@ -417,11 +459,39 @@ class TrainTaskViewTests(ComputeTaskViewTests):
         done_train_task = train_tasks[ComputeTask.Status.STATUS_DONE]
         failed_train_task = train_tasks[ComputeTask.Status.STATUS_FAILED]
         canceled_train_task = train_tasks[ComputeTask.Status.STATUS_CANCELED]
+        train_inputs = [
+            {
+                "identifier": "datasamples",
+                "asset_key": str(self.data_sample.key),
+                "parent_task_key": None,
+                "parent_task_output_identifier": None,
+            },
+            {
+                "identifier": "opener",
+                "asset_key": str(self.data_manager.key),
+                "parent_task_key": None,
+                "parent_task_output_identifier": None,
+                "addressable": self.data_manager_data["opener"],
+                "permissions": self.data_manager_data["permissions"],
+            },
+        ]
+        train_outputs = {
+            "model": {
+                "permissions": {
+                    "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
+                    "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
+                },
+                "transient": False,
+                "value": None,
+            },
+        }
+        done_train_outputs = copy.deepcopy(train_outputs)
+        done_train_outputs["model"]["value"] = self.train_model_data
         self.expected_results = [
             {
                 "key": str(todo_train_task.key),
                 "category": "TASK_TRAIN",
-                "algo": self.algo_data[Algo.Category.ALGO_SIMPLE],
+                "algo": self.simple_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -454,22 +524,13 @@ class TrainTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 0,  # because start_date is None
-                "inputs": _build_inputs(ComputeTask.Category.TASK_TRAIN),
-                "outputs": {
-                    "model": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                },
+                "inputs": train_inputs,
+                "outputs": train_outputs,
             },
             {
                 "key": str(waiting_train_task.key),
                 "category": "TASK_TRAIN",
-                "algo": self.algo_data[Algo.Category.ALGO_SIMPLE],
+                "algo": self.simple_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -502,22 +563,13 @@ class TrainTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 0,  # because start_date is None
-                "inputs": _build_inputs(ComputeTask.Category.TASK_TRAIN),
-                "outputs": {
-                    "model": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                },
+                "inputs": train_inputs,
+                "outputs": train_outputs,
             },
             {
                 "key": str(doing_train_task.key),
                 "category": "TASK_TRAIN",
-                "algo": self.algo_data[Algo.Category.ALGO_SIMPLE],
+                "algo": self.simple_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -550,22 +602,13 @@ class TrainTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 3600,
-                "inputs": _build_inputs(ComputeTask.Category.TASK_TRAIN),
-                "outputs": {
-                    "model": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                },
+                "inputs": train_inputs,
+                "outputs": train_outputs,
             },
             {
                 "key": str(done_train_task.key),
                 "category": "TASK_TRAIN",
-                "algo": self.algo_data[Algo.Category.ALGO_SIMPLE],
+                "algo": self.simple_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -598,22 +641,13 @@ class TrainTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 3600,
-                "inputs": _build_inputs(ComputeTask.Category.TASK_TRAIN),
-                "outputs": {
-                    "model": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": self.train_model_data,
-                    },
-                },
+                "inputs": train_inputs,
+                "outputs": done_train_outputs,
             },
             {
                 "key": str(failed_train_task.key),
                 "category": "TASK_TRAIN",
-                "algo": self.algo_data[Algo.Category.ALGO_SIMPLE],
+                "algo": self.simple_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -646,22 +680,13 @@ class TrainTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 3600,
-                "inputs": _build_inputs(ComputeTask.Category.TASK_TRAIN),
-                "outputs": {
-                    "model": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                },
+                "inputs": train_inputs,
+                "outputs": train_outputs,
             },
             {
                 "key": str(canceled_train_task.key),
                 "category": "TASK_TRAIN",
-                "algo": self.algo_data[Algo.Category.ALGO_SIMPLE],
+                "algo": self.simple_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -694,17 +719,8 @@ class TrainTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 3600,
-                "inputs": _build_inputs(ComputeTask.Category.TASK_TRAIN),
-                "outputs": {
-                    "model": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                },
+                "inputs": train_inputs,
+                "outputs": train_outputs,
             },
         ]
 
@@ -894,7 +910,7 @@ class TrainTaskViewTests(ComputeTaskViewTests):
         # filter on asset keys
         params_list = [
             urlencode({"compute_plan_key": self.compute_plan.key}),
-            urlencode({"algo_key": self.algos[Algo.Category.ALGO_SIMPLE].key}),
+            urlencode({"algo_key": self.simple_algo.key}),
             urlencode({"dataset_key": self.data_manager.key}),
             urlencode({"data_sample_key": self.data_sample.key}),
         ]
@@ -969,11 +985,39 @@ class TestTaskViewTests(ComputeTaskViewTests):
         done_test_task = test_tasks[ComputeTask.Status.STATUS_DONE]
         failed_test_task = test_tasks[ComputeTask.Status.STATUS_FAILED]
         canceled_test_task = test_tasks[ComputeTask.Status.STATUS_CANCELED]
+        test_inputs = [
+            {
+                "identifier": "datasamples",
+                "asset_key": str(self.data_sample.key),
+                "parent_task_key": None,
+                "parent_task_output_identifier": None,
+            },
+            {
+                "identifier": "opener",
+                "asset_key": str(self.data_manager.key),
+                "parent_task_key": None,
+                "parent_task_output_identifier": None,
+                "addressable": self.data_manager_data["opener"],
+                "permissions": self.data_manager_data["permissions"],
+            },
+        ]
+        test_outputs = {
+            "performance": {
+                "permissions": {
+                    "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
+                    "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
+                },
+                "transient": False,
+                "value": None,
+            },
+        }
+        done_test_outputs = copy.deepcopy(test_outputs)
+        done_test_outputs["performance"]["value"] = self.performance.value
         self.expected_results = [
             {
                 "key": str(todo_test_task.key),
                 "category": "TASK_TEST",
-                "algo": self.algo_data[Algo.Category.ALGO_METRIC],
+                "algo": self.metric_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -996,22 +1040,13 @@ class TestTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 0,
-                "inputs": _build_inputs(ComputeTask.Category.TASK_TEST),
-                "outputs": {
-                    "performance": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                },
+                "inputs": test_inputs,
+                "outputs": test_outputs,
             },
             {
                 "key": str(waiting_test_task.key),
                 "category": "TASK_TEST",
-                "algo": self.algo_data[Algo.Category.ALGO_METRIC],
+                "algo": self.metric_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -1034,22 +1069,13 @@ class TestTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 0,
-                "inputs": _build_inputs(ComputeTask.Category.TASK_TEST),
-                "outputs": {
-                    "performance": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                },
+                "inputs": test_inputs,
+                "outputs": test_outputs,
             },
             {
                 "key": str(doing_test_task.key),
                 "category": "TASK_TEST",
-                "algo": self.algo_data[Algo.Category.ALGO_METRIC],
+                "algo": self.metric_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -1072,22 +1098,13 @@ class TestTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 3600,
-                "inputs": _build_inputs(ComputeTask.Category.TASK_TEST),
-                "outputs": {
-                    "performance": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                },
+                "inputs": test_inputs,
+                "outputs": test_outputs,
             },
             {
                 "key": str(done_test_task.key),
                 "category": "TASK_TEST",
-                "algo": self.algo_data[Algo.Category.ALGO_METRIC],
+                "algo": self.metric_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -1103,29 +1120,20 @@ class TestTaskViewTests(ComputeTaskViewTests):
                 "test": {
                     "data_manager_key": str(self.data_manager.key),
                     "data_sample_keys": [str(self.data_sample.key)],
-                    "perfs": {str(self.algos[Algo.Category.ALGO_METRIC].key): self.performance.value},
+                    "perfs": {str(self.metric_algo.key): self.performance.value},
                 },
                 "logs_permission": {
                     "public": False,
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 3600,
-                "inputs": _build_inputs(ComputeTask.Category.TASK_TEST),
-                "outputs": {
-                    "performance": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": self.performance.value,
-                    },
-                },
+                "inputs": test_inputs,
+                "outputs": done_test_outputs,
             },
             {
                 "key": str(failed_test_task.key),
                 "category": "TASK_TEST",
-                "algo": self.algo_data[Algo.Category.ALGO_METRIC],
+                "algo": self.metric_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -1148,22 +1156,13 @@ class TestTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 3600,
-                "inputs": _build_inputs(ComputeTask.Category.TASK_TEST),
-                "outputs": {
-                    "performance": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                },
+                "inputs": test_inputs,
+                "outputs": test_outputs,
             },
             {
                 "key": str(canceled_test_task.key),
                 "category": "TASK_TEST",
-                "algo": self.algo_data[Algo.Category.ALGO_METRIC],
+                "algo": self.metric_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -1186,17 +1185,8 @@ class TestTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 3600,
-                "inputs": _build_inputs(ComputeTask.Category.TASK_TEST),
-                "outputs": {
-                    "performance": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                },
+                "inputs": test_inputs,
+                "outputs": test_outputs,
             },
         ]
 
@@ -1210,7 +1200,6 @@ class TestTaskViewTests(ComputeTaskViewTests):
         response = self.client.get(self.url, **self.extra)
         # manually overriding duration for doing tasks as "now" is taken from db and not timezone.now(),
         # couldn't be properly mocked
-        self.maxDiff = None
         for task in response.json().get("results"):
             if task["status"] == ComputeTask.Status.STATUS_DOING:
                 task["duration"] = 3600
@@ -1318,7 +1307,7 @@ class TestTaskViewTests(ComputeTaskViewTests):
         # filter on asset keys
         params_list = [
             urlencode({"compute_plan_key": self.compute_plan.key}),
-            urlencode({"algo_key": self.algos[Algo.Category.ALGO_METRIC].key}),
+            urlencode({"algo_key": self.metric_algo.key}),
             urlencode({"dataset_key": self.data_manager.key}),
             urlencode({"data_sample_key": self.data_sample.key}),
         ]
@@ -1367,7 +1356,6 @@ class TestTaskViewTests(ComputeTaskViewTests):
         for task in response.json().get("results"):
             if task["status"] == ComputeTask.Status.STATUS_DOING:
                 task["duration"] = 3600
-                self.maxDiff = None
         self.assertEqual(
             response.json(),
             {"count": len(self.expected_results), "next": None, "previous": None, "results": self.expected_results},
@@ -1429,11 +1417,48 @@ class CompositeTaskViewTests(ComputeTaskViewTests):
         done_composite_task = composite_tasks[ComputeTask.Status.STATUS_DONE]
         failed_composite_task = composite_tasks[ComputeTask.Status.STATUS_FAILED]
         canceled_composite_task = composite_tasks[ComputeTask.Status.STATUS_CANCELED]
+        composite_inputs = [
+            {
+                "identifier": "datasamples",
+                "asset_key": str(self.data_sample.key),
+                "parent_task_key": None,
+                "parent_task_output_identifier": None,
+            },
+            {
+                "identifier": "opener",
+                "asset_key": str(self.data_manager.key),
+                "parent_task_key": None,
+                "parent_task_output_identifier": None,
+                "addressable": self.data_manager_data["opener"],
+                "permissions": self.data_manager_data["permissions"],
+            },
+        ]
+        composite_outputs = {
+            "local": {
+                "permissions": {
+                    "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
+                    "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
+                },
+                "transient": False,
+                "value": None,
+            },
+            "shared": {
+                "permissions": {
+                    "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
+                    "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
+                },
+                "transient": False,
+                "value": None,
+            },
+        }
+        done_composite_outputs = copy.deepcopy(composite_outputs)
+        done_composite_outputs["local"]["value"] = self.local_model_data
+        done_composite_outputs["shared"]["value"] = self.shared_model_data
         self.expected_results = [
             {
                 "key": str(todo_composite_task.key),
                 "category": "TASK_COMPOSITE",
-                "algo": self.algo_data[Algo.Category.ALGO_COMPOSITE],
+                "algo": self.composite_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -1476,30 +1501,13 @@ class CompositeTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 0,
-                "inputs": _build_inputs(ComputeTask.Category.TASK_COMPOSITE),
-                "outputs": {
-                    "local": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                    "shared": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                },
+                "inputs": composite_inputs,
+                "outputs": composite_outputs,
             },
             {
                 "key": str(waiting_composite_task.key),
                 "category": "TASK_COMPOSITE",
-                "algo": self.algo_data[Algo.Category.ALGO_COMPOSITE],
+                "algo": self.composite_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -1542,30 +1550,13 @@ class CompositeTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 0,
-                "inputs": _build_inputs(ComputeTask.Category.TASK_COMPOSITE),
-                "outputs": {
-                    "local": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                    "shared": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                },
+                "inputs": composite_inputs,
+                "outputs": composite_outputs,
             },
             {
                 "key": str(doing_composite_task.key),
                 "category": "TASK_COMPOSITE",
-                "algo": self.algo_data[Algo.Category.ALGO_COMPOSITE],
+                "algo": self.composite_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -1608,30 +1599,13 @@ class CompositeTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 3600,
-                "inputs": _build_inputs(ComputeTask.Category.TASK_COMPOSITE),
-                "outputs": {
-                    "local": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                    "shared": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                },
+                "inputs": composite_inputs,
+                "outputs": composite_outputs,
             },
             {
                 "key": str(done_composite_task.key),
                 "category": "TASK_COMPOSITE",
-                "algo": self.algo_data[Algo.Category.ALGO_COMPOSITE],
+                "algo": self.composite_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -1674,30 +1648,13 @@ class CompositeTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 3600,
-                "inputs": _build_inputs(ComputeTask.Category.TASK_COMPOSITE),
-                "outputs": {
-                    "local": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": self.local_model_data,
-                    },
-                    "shared": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": self.shared_model_data,
-                    },
-                },
+                "inputs": composite_inputs,
+                "outputs": done_composite_outputs,
             },
             {
                 "key": str(failed_composite_task.key),
                 "category": "TASK_COMPOSITE",
-                "algo": self.algo_data[Algo.Category.ALGO_COMPOSITE],
+                "algo": self.composite_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -1740,30 +1697,13 @@ class CompositeTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 3600,
-                "inputs": _build_inputs(ComputeTask.Category.TASK_COMPOSITE),
-                "outputs": {
-                    "local": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                    "shared": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                },
+                "inputs": composite_inputs,
+                "outputs": composite_outputs,
             },
             {
                 "key": str(canceled_composite_task.key),
                 "category": "TASK_COMPOSITE",
-                "algo": self.algo_data[Algo.Category.ALGO_COMPOSITE],
+                "algo": self.composite_algo_data,
                 "owner": "MyOrg1MSP",
                 "compute_plan_key": str(self.compute_plan.key),
                 "metadata": {},
@@ -1806,25 +1746,8 @@ class CompositeTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 3600,
-                "inputs": _build_inputs(ComputeTask.Category.TASK_COMPOSITE),
-                "outputs": {
-                    "local": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                    "shared": {
-                        "permissions": {
-                            "download": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                            "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
-                        },
-                        "transient": False,
-                        "value": None,
-                    },
-                },
+                "inputs": composite_inputs,
+                "outputs": composite_outputs,
             },
         ]
 
@@ -1931,7 +1854,7 @@ class CompositeTaskViewTests(ComputeTaskViewTests):
         # filter on asset keys
         params_list = [
             urlencode({"compute_plan_key": self.compute_plan.key}),
-            urlencode({"algo_key": self.algos[Algo.Category.ALGO_COMPOSITE].key}),
+            urlencode({"algo_key": self.composite_algo.key}),
             urlencode({"dataset_key": self.data_manager.key}),
             urlencode({"data_sample_key": self.data_sample.key}),
         ]
@@ -2023,35 +1946,3 @@ class CompositeTaskViewTests(ComputeTaskViewTests):
         url = reverse("api:composite_traintuple-detail", args=[self.expected_results[0]["key"]])
         response = self.client.get(url, **self.extra)
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
-
-
-def _build_inputs(category: str) -> list[dict]:
-    # match the factory: create one input for each identifier, ordered alphabetically
-    if category == ComputeTask.Category.TASK_TRAIN:
-        return [_build_input("datasamples"), _build_input("model"), _build_input("opener")]
-    elif category == ComputeTask.Category.TASK_COMPOSITE:
-        return [_build_input("datasamples"), _build_input("local"), _build_input("opener"), _build_input("shared")]
-    elif category == ComputeTask.Category.TASK_AGGREGATE:
-        return [_build_input("model")]
-    elif category == ComputeTask.Category.TASK_PREDICT:
-        return [_build_input("datasamples"), _build_input("model"), _build_input("opener"), _build_input("shared")]
-    elif category == ComputeTask.Category.TASK_TEST:
-        return [_build_input("datasamples"), _build_input("opener"), _build_input("predictions")]
-
-
-def _build_input(identifier):
-    if identifier == "opener":
-        return {
-            "asset_key": factory.INPUT_ASSET_KEY,
-            "identifier": identifier,
-            "parent_task_key": None,
-            "parent_task_output_identifier": None,
-            "addressable": None,
-            "permissions": None,
-        }
-    return {
-        "asset_key": factory.INPUT_ASSET_KEY,
-        "identifier": identifier,
-        "parent_task_key": None,
-        "parent_task_output_identifier": None,
-    }

--- a/backend/api/tests/views/test_views_performance.py
+++ b/backend/api/tests/views/test_views_performance.py
@@ -36,11 +36,15 @@ class CPPerformanceViewTests(APITestCase):
         self.extra = {"HTTP_SUBSTRA_CHANNEL_NAME": "mychannel", "HTTP_ACCEPT": "application/json;version=0.0"}
         self.url = reverse("api:compute_plan_perf-list", args=[self.compute_plan.key])
 
-        self.metric = factory.create_algo(category=Algo.Category.ALGO_METRIC)
+        self.metric = factory.create_algo(
+            outputs=factory.build_algo_outputs(["performance"]),
+            category=Algo.Category.ALGO_METRIC,
+        )
         self.compute_tasks = [
             factory.create_computetask(
                 self.compute_plan,
-                algo=self.metric,
+                self.metric,
+                outputs=factory.build_computetask_outputs(self.metric),
                 data_manager=self.data_manager,
                 data_samples=[self.data_sample.key],
                 category=ComputeTask.Category.TASK_TEST,
@@ -51,7 +55,14 @@ class CPPerformanceViewTests(APITestCase):
             )
             for i in range(3)
         ]
-        self.performances = [factory.create_performance(self.compute_tasks[i], self.metric) for i in range(3)]
+        self.performances = [
+            factory.create_performance(
+                self.compute_tasks[i],
+                self.metric,
+                identifier="performance",
+            )
+            for i in range(3)
+        ]
         self.expected_stats = {
             "compute_tasks_distinct_ranks": [1, 2, 3],
             "compute_tasks_distinct_rounds": [1],
@@ -164,11 +175,18 @@ class PerformanceViewTests(APITestCase):
         self.export_extra = {"HTTP_SUBSTRA_CHANNEL_NAME": "mychannel", "HTTP_ACCEPT": "*/*"}
         self.export_url = reverse("api:performance-export")
 
-        self.metrics = [factory.create_algo(category=Algo.Category.ALGO_METRIC) for _ in range(3)]
+        self.metrics = [
+            factory.create_algo(
+                outputs=factory.build_algo_outputs(["performance"]),
+                category=Algo.Category.ALGO_METRIC,
+            )
+            for _ in range(3)
+        ]
         self.compute_tasks = [
             factory.create_computetask(
                 self.compute_plans[i],
-                algo=self.metrics[i],
+                self.metrics[i],
+                outputs=factory.build_computetask_outputs(self.metrics[i]),
                 data_manager=self.data_manager,
                 data_samples=[self.data_sample.key],
                 category=ComputeTask.Category.TASK_TEST,
@@ -177,8 +195,24 @@ class PerformanceViewTests(APITestCase):
             )
             for i in range(2)
         ]
-        self.performances = [factory.create_performance(self.compute_tasks[0], self.metrics[i]) for i in range(3)]
-        self.performances.extend([factory.create_performance(self.compute_tasks[1], self.metrics[i]) for i in range(3)])
+        self.performances = [
+            factory.create_performance(
+                self.compute_tasks[0],
+                self.metrics[i],
+                identifier="performance",
+            )
+            for i in range(3)
+        ]
+        self.performances.extend(
+            [
+                factory.create_performance(
+                    self.compute_tasks[1],
+                    self.metrics[i],
+                    identifier="performance",
+                )
+                for i in range(3)
+            ]
+        )
         self.expected_results = [
             {
                 "compute_plan_key": self.compute_plans[0],


### PR DESCRIPTION
## Description

Provides inputs/outputs to the algo and compute task factory, instead of inferring static values from category.
- It removes dependency to the categories we want to deprecate.
- It provides valid task input keys instead of random uuid which is needed to test serializers (required for #458).

Before

```python
algo = create_algo(
    category=Algo.Category.ALGO_SIMPLE,
)
train_task = create_computetask(
    compute_plan,
    algo,
    category=ComputeTask.Category.TASK_TRAIN,
    ...
)

metric = create_algo(
    category=Algo.Category.ALGO_METRIC,
)
test_task = create_computetask(
    compute_plan,
    metric,
    category=ComputeTask.Category.TASK_TEST,
    ...
)
```

After:

```python
algo = create_algo(
    inputs=factory.build_algo_inputs(["datasamples", "opener"]),
    outputs=factory.build_algo_outputs(["model"]),
)
train_task = create_computetask(
    compute_plan,
    algo,
    inputs=factory.build_computetask_inputs(
        algo,
        {
            "opener": [data_manager.key],
            "datasamples": [data_sample.key],
        },
    ),
    outputs=factory.build_computetask_outputs(algo),
    ...
)

metric = create_algo(
    inputs=factory.build_algo_inputs(["datasamples", "opener", "model"]),
    outputs=factory.build_algo_outputs(["performance"]),
)
test_task = create_computetask(
    compute_plan,
    metric,
    inputs=factory.build_computetask_inputs(
        metric,
        {
            "opener": [data_manager.key],
            "datasamples": [data_sample.key],
            "model": [train_task.key],
        },
    ),
    outputs=factory.build_computetask_outputs(metric),
    ...
)
```

## How has this been tested?

E2e not needed as only test modules are changed.

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203055469585066