### PR TITLE
feat: update following the metric change in substratools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BREAKING: remove `delete_intermediary_models` field from the `compute_plan` view.
 - Use task output asset in API response
 - Add channel column to input/output tables.
+- The test task uses the same CLI arguments format as the other tasks.
 
 ## [0.30.0] 2022-09-19
 

--- a/backend/substrapp/compute_tasks/command.py
+++ b/backend/substrapp/compute_tasks/command.py
@@ -46,15 +46,6 @@ def _get_args(ctx: Context) -> list[str]:  # noqa: C901
 
     inputs = []
     outputs = []
-
-    if task_category == orchestrator.ComputeTaskCategory.TASK_TEST:
-        perf_output = [o for o in ctx.outputs if o.kind == orchestrator.AssetKind.ASSET_PERFORMANCE][0]
-        command = ["--input-predictions-path", os.path.join(in_models_dir, ctx.input_models[0].key)]
-        command += ["--opener-path", os.path.join(openers_dir, ctx.data_manager.key, Filenames.Opener)]
-        command += ["--data-sample-paths"] + [os.path.join(datasamples_dir, key) for key in ctx.data_sample_keys]
-        command += ["--output-perf-path", os.path.join(SANDBOX_DIR, perf_output.rel_path)]
-        return command
-
     command = []
 
     # TODO: refactor path handling in context to iterate over all inputs at once

--- a/backend/substrapp/tests/compute_tasks/test_command.py
+++ b/backend/substrapp/tests/compute_tasks/test_command.py
@@ -400,7 +400,11 @@ def test_get_args_test_after_predict():
     ]
 
     expected_outputs = [
-        {"id": InputIdentifiers.PERFORMANCE, "value": f"/substra_internal/perf/{InputIdentifiers.PERFORMANCE}-perf.json", "multiple": False},
+        {
+            "id": InputIdentifiers.PERFORMANCE,
+            "value": f"/substra_internal/perf/{InputIdentifiers.PERFORMANCE}-perf.json",
+            "multiple": False,
+        },
     ]
 
     actual = _get_args(ctx)

--- a/backend/substrapp/tests/compute_tasks/test_command.py
+++ b/backend/substrapp/tests/compute_tasks/test_command.py
@@ -405,6 +405,8 @@ def test_get_args_test_after_predict():
 
     actual = _get_args(ctx)
     assert actual == [
+        "--rank",
+        "0",
         "--inputs",
         f"'{json.dumps(expected_inputs)}'",
         "--outputs",

--- a/fixtures/chunantes/metrics/metric0/metrics.py
+++ b/fixtures/chunantes/metrics/metric0/metrics.py
@@ -2,10 +2,10 @@ import substratools as tools
 from sklearn.metrics import recall_score
 
 
-class Metrics(tools.Metrics):
+class Metrics(tools.MetricAlgo):
     def score(self, y_true, y_pred):
         return recall_score(y_true.argmax(axis=1), y_pred.argmax(axis=1), average="macro")
 
 
 if __name__ == "__main__":
-    tools.metrics.execute(Metrics())
+    tools.algo.execute(Metrics())

--- a/fixtures/owkin/metrics/metric0/metrics.py
+++ b/fixtures/owkin/metrics/metric0/metrics.py
@@ -2,10 +2,10 @@ import substratools as tools
 from sklearn.metrics import recall_score
 
 
-class Metrics(tools.Metrics):
+class Metrics(tools.MetricAlgo):
     def score(self, y_true, y_pred):
         return recall_score(y_true.argmax(axis=1), y_pred.argmax(axis=1), average="macro")
 
 
 if __name__ == "__main__":
-    tools.metrics.execute(Metrics())
+    tools.algo.execute(Metrics())


### PR DESCRIPTION
## Description

DISCLAIMER: I am not very used to making PRs on the backend, please tell me if anything is missing

https://github.com/Substra/substra-tools/pull/60/files

The `Metrics` class from substratools:
- now inherits from the `GenericAlgo`
- is renamed `MetricAlgo`
- the CLI args are the same as the other algos (inputs, outputs)

## How has this been tested?

e2e tests on the substra tools PR
unit tests


## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
