### PR TITLE
fix: pass substra-tools arguments via a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add channel column to input/output tables.
 - The test task uses the same CLI arguments format as the other tasks.
 
+### Fixed
+
+- Bug when executing compute tasks with too many data samples (command line length exceeding max.) The substra-tools arguments are now passed using a file.
+
 ## [0.30.0] 2022-09-19
 
 ### Changed

--- a/backend/substrapp/compute_tasks/command.py
+++ b/backend/substrapp/compute_tasks/command.py
@@ -7,6 +7,7 @@ import orchestrator
 from substrapp.compute_tasks.context import Context
 from substrapp.compute_tasks.context import TaskResource
 from substrapp.compute_tasks.directories import SANDBOX_DIR
+from substrapp.compute_tasks.directories import Directories
 from substrapp.compute_tasks.directories import TaskDirName
 from substrapp.models.image_entrypoint import ImageEntrypoint
 
@@ -19,6 +20,7 @@ TASK_IO_CHAINKEYS = "chainkeys"
 
 class Filenames:
     Opener = "__init__.py"
+    CliArgs = "arguments.txt"
 
 
 def get_exec_command(ctx: Context) -> list[str]:
@@ -29,13 +31,14 @@ def get_exec_command(ctx: Context) -> list[str]:
     if command[0].startswith("python"):
         command.insert(1, "-u")  # unbuffered. Allows streaming the logs in real-time.
 
-    args = _get_args(ctx)
+    # Pass the command line arguments via a file
+    command.append("@" + os.path.join(SANDBOX_DIR, TaskDirName.CliArgs, Filenames.CliArgs))
 
-    return command + args
+    return command
 
 
-# TODO: '_get_args' is too complex, consider refactoring
-def _get_args(ctx: Context) -> list[str]:  # noqa: C901
+def get_exec_command_args(ctx: Context) -> list[str]:
+    """Return the substra-tools command line arguments"""
     task = ctx.task
     task_category = ctx.task.category
 
@@ -46,7 +49,6 @@ def _get_args(ctx: Context) -> list[str]:  # noqa: C901
 
     inputs = []
     outputs = []
-    command = []
 
     # TODO: refactor path handling in context to iterate over all inputs at once
     inputs.extend(
@@ -86,15 +88,30 @@ def _get_args(ctx: Context) -> list[str]:  # noqa: C901
     for output in ctx.outputs:
         outputs.append(TaskResource(id=output.identifier, value=os.path.join(SANDBOX_DIR, output.rel_path)))
 
+    args = []
+
     rank = str(task.rank)
     if rank and task_category != orchestrator.ComputeTaskCategory.TASK_PREDICT:
-        command += ["--rank", rank]
+        args += ["--rank", rank]
     if ctx.has_chainkeys:
         inputs.append(TaskResource(id=TASK_IO_CHAINKEYS, value=chainkeys_folder))
 
-    command += ["--inputs", f"'{json.dumps(inputs)}'"]
-    command += ["--outputs", f"'{json.dumps(outputs)}'"]
+    args += ["--inputs", json.dumps(inputs)]
+    args += ["--outputs", json.dumps(outputs)]
 
-    logger.debug("Generated task command", command=command)
+    logger.debug("Generated substra-tools arguments", args=args)
 
-    return command
+    return args
+
+
+def write_command_args_file(dirs: Directories, command_args: list[str]) -> None:
+    """Write the substra-tools command line arguments to a file.
+
+    The format uses one line per argument. See
+    https://docs.python.org/3/library/argparse.html#fromfile-prefix-chars
+    """
+    path = os.path.join(dirs.task_dir, TaskDirName.CliArgs, Filenames.CliArgs)
+
+    with open(path, "w") as f:
+        for item in command_args:
+            f.write(item + "\n")

--- a/backend/substrapp/compute_tasks/directories.py
+++ b/backend/substrapp/compute_tasks/directories.py
@@ -14,16 +14,17 @@ SANDBOX_DIR = "/substra_internal"
 
 
 # /var/medias/substra/subtuple     <- SUBTUPLE_DIR
-#
-# └── asset_buffer                 <- ASSET_BUFFER_DIR
-#     ├── data_samples
-#     ├── models
-#     └── openers
-#
+# |
+# ├── asset_buffer                 <- ASSET_BUFFER_DIR
+# |   ├── data_samples
+# |   ├── models
+# |   └── openers
+# |
 # └── <compute_plan_key>           <- compute_plan_dir
 #     ├── chainkeys
 #     └── task                     <- task_dir
 #         ├── chainkeys
+#         ├── cli-args
 #         ├── data_samples
 #         ├── export
 #         ├── in_models
@@ -50,6 +51,7 @@ class CPDirName:
 
 class TaskDirName:
     Chainkeys = "chainkeys"
+    CliArgs = "cli-args"
     Datasamples = "data_samples"
     Export = "export"
     InModels = "in_models"
@@ -57,7 +59,7 @@ class TaskDirName:
     OutModels = "out_models"
     Perf = "perf"
 
-    All = [Chainkeys, Datasamples, Export, InModels, Openers, OutModels, Perf]
+    All = [Chainkeys, CliArgs, Datasamples, Export, InModels, Openers, OutModels, Perf]
 
 
 class Directories:

--- a/backend/substrapp/compute_tasks/volumes.py
+++ b/backend/substrapp/compute_tasks/volumes.py
@@ -17,6 +17,7 @@ def get_volumes(ctx: Context):
     # ...
     volume_mounts.extend(
         [
+            _create_mount(dirs.task_dir, TaskDirName.CliArgs, read_only=True),
             _create_mount(dirs.task_dir, TaskDirName.Datasamples, read_only=True),
             _create_mount(dirs.task_dir, TaskDirName.Export),
             _create_mount(dirs.task_dir, TaskDirName.InModels, read_only=True),

--- a/backend/substrapp/tests/compute_tasks/test_command.py
+++ b/backend/substrapp/tests/compute_tasks/test_command.py
@@ -4,7 +4,7 @@ import orchestrator
 import orchestrator.mock as orc_mock
 from orchestrator.resources import ComputeTaskInputAsset
 from substrapp.compute_tasks import context
-from substrapp.compute_tasks.command import _get_args
+from substrapp.compute_tasks.command import get_exec_command_args
 from substrapp.compute_tasks.directories import Directories
 from substrapp.tests.common import InputIdentifiers
 
@@ -77,14 +77,14 @@ def test_get_args_train_task():
         {"id": InputIdentifiers.MODEL, "value": "/substra_internal/out_models/out-model", "multiple": False},
     ]
 
-    actual = _get_args(ctx)
+    actual = get_exec_command_args(ctx)
     assert actual == [
         "--rank",
         "0",
         "--inputs",
-        f"'{json.dumps(expected_inputs)}'",
+        json.dumps(expected_inputs),
         "--outputs",
-        f"'{json.dumps(expected_outputs)}'",
+        json.dumps(expected_outputs),
     ]
 
 
@@ -167,14 +167,14 @@ def test_get_args_composite_task():
         {"id": InputIdentifiers.SHARED, "value": "/substra_internal/out_models/out-model", "multiple": False},
     ]
 
-    actual = _get_args(ctx)
+    actual = get_exec_command_args(ctx)
     assert actual == [
         "--rank",
         "0",
         "--inputs",
-        f"'{json.dumps(expected_inputs)}'",
+        json.dumps(expected_inputs),
         "--outputs",
-        f"'{json.dumps(expected_outputs)}'",
+        json.dumps(expected_outputs),
     ]
 
 
@@ -244,12 +244,12 @@ def test_get_args_predict_after_train():
         {"id": InputIdentifiers.PREDICTIONS, "value": "/substra_internal/out_models/out-model", "multiple": False},
     ]
 
-    actual = _get_args(ctx)
+    actual = get_exec_command_args(ctx)
     assert actual == [
         "--inputs",
-        f"'{json.dumps(expected_inputs)}'",
+        json.dumps(expected_inputs),
         "--outputs",
-        f"'{json.dumps(expected_outputs)}'",
+        json.dumps(expected_outputs),
     ]
 
 
@@ -325,12 +325,12 @@ def test_get_args_predict_after_composite():
         {"id": InputIdentifiers.PREDICTIONS, "value": "/substra_internal/out_models/out-model", "multiple": False},
     ]
 
-    actual = _get_args(ctx)
+    actual = get_exec_command_args(ctx)
     assert actual == [
         "--inputs",
-        f"'{json.dumps(expected_inputs)}'",
+        json.dumps(expected_inputs),
         "--outputs",
-        f"'{json.dumps(expected_outputs)}'",
+        json.dumps(expected_outputs),
     ]
 
 
@@ -407,12 +407,12 @@ def test_get_args_test_after_predict():
         },
     ]
 
-    actual = _get_args(ctx)
+    actual = get_exec_command_args(ctx)
     assert actual == [
         "--rank",
         "0",
         "--inputs",
-        f"'{json.dumps(expected_inputs)}'",
+        json.dumps(expected_inputs),
         "--outputs",
-        f"'{json.dumps(expected_outputs)}'",
+        json.dumps(expected_outputs),
     ]

--- a/backend/substrapp/tests/compute_tasks/test_execute.py
+++ b/backend/substrapp/tests/compute_tasks/test_execute.py
@@ -15,10 +15,15 @@ def test_exec_success(mocker: MockerFixture):
     mock_get_exec_stream = mocker.patch("substrapp.compute_tasks.execute.execute")
     mock_get_exec_stream.return_value = execution_stream
 
+    ctx = mocker.Mock()
+    ctx.directories = mocker.Mock()
     pod = compute_pod.ComputePod(str(uuid.uuid4()), str(uuid.uuid4()))
-    cmd = ["ls", "/tmp"]
 
-    execute._exec(pod, cmd)
+    mocker.patch("substrapp.compute_tasks.execute.get_exec_command", return_value=["ls", "/tmp"])
+    mocker.patch("substrapp.compute_tasks.execute.get_exec_command_args")
+    mocker.patch("substrapp.compute_tasks.execute.write_command_args_file")
+
+    execute._exec(ctx, pod)
 
     mock_get_exec_stream.assert_called_once()
 
@@ -31,11 +36,16 @@ def test_exec_failure(mocker: MockerFixture):
     mock_get_exec_stream = mocker.patch("substrapp.compute_tasks.execute.execute")
     mock_get_exec_stream.return_value = execution_stream
 
+    ctx = mocker.Mock()
+    ctx.directories = mocker.Mock()
     pod = compute_pod.ComputePod(str(uuid.uuid4()), str(uuid.uuid4()))
-    cmd = ["l", "/tmp"]
+
+    mocker.patch("substrapp.compute_tasks.execute.get_exec_command", return_value=["ls", "/tmp"])
+    mocker.patch("substrapp.compute_tasks.execute.get_exec_command_args")
+    mocker.patch("substrapp.compute_tasks.execute.write_command_args_file")
 
     with pytest.raises(ExecutionError) as exc:
-        execute._exec(pod, cmd)
+        execute._exec(ctx, pod)
 
     assert str(retcode) in str(exc.value)
     mock_get_exec_stream.assert_called_once()


### PR DESCRIPTION
Companion PRs:

- https://github.com/Substra/substra-tools/pull/55 (main PR)
- https://github.com/Substra/substra/pull/279
- https://github.com/Substra/substra-backend/pull/473 (this PR)

---

This fixes a bug when the substra-tools command line argument list is too long.