### PR TITLE
feat(workflow_graph): Added the input and output kinds in response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use task output asset in API response
 - Add channel column to input/output tables.
 - The test task uses the same CLI arguments format as the other tasks.
+- Add inputs and output kinds in the workflow_graph response
 
 ## [0.30.0] 2022-09-19
 

--- a/backend/api/tests/views/test_views_compute_plan_graph.py
+++ b/backend/api/tests/views/test_views_compute_plan_graph.py
@@ -72,6 +72,7 @@ class ComputePlanGraphViewTests(APITestCase):
             compute_plan, algo=algo, category=ComputeTask.Category.TASK_AGGREGATE, parent_tasks=[composite_task.key]
         )
 
+        self.maxDiff = None
         expected_results = {
             "tasks": [
                 {
@@ -80,8 +81,8 @@ class ComputePlanGraphViewTests(APITestCase):
                     "worker": "MyOrg1MSP",
                     "status": "STATUS_TODO",
                     "category": "TASK_TRAIN",
-                    "inputs": ["in/model"],
-                    "outputs": ["out/model"],
+                    "inputs": [{"id": "in/model", "kind": "model"}],
+                    "outputs": [{"id": "out/model", "kind": "model"}],
                 },
                 {
                     "key": str(predict_task.key),
@@ -89,8 +90,8 @@ class ComputePlanGraphViewTests(APITestCase):
                     "worker": "MyOrg1MSP",
                     "status": "STATUS_TODO",
                     "category": "TASK_PREDICT",
-                    "inputs": ["in/tested_model"],
-                    "outputs": ["out/predictions"],
+                    "inputs": [{"id": "in/tested_model", "kind": "model"}],
+                    "outputs": [{"id": "out/predictions", "kind": "model"}],
                 },
                 {
                     "key": str(test_task.key),
@@ -98,8 +99,8 @@ class ComputePlanGraphViewTests(APITestCase):
                     "worker": "MyOrg1MSP",
                     "status": "STATUS_TODO",
                     "category": "TASK_TEST",
-                    "inputs": ["in/predictions"],
-                    "outputs": [],
+                    "inputs": [{"id": "in/predictions", "kind": "model"}],
+                    "outputs": [{"id": "out/perf", "kind": "performance"}],
                 },
                 {
                     "key": str(composite_task.key),
@@ -107,8 +108,8 @@ class ComputePlanGraphViewTests(APITestCase):
                     "worker": "MyOrg1MSP",
                     "status": "STATUS_TODO",
                     "category": "TASK_COMPOSITE",
-                    "inputs": ["in/head_model", "in/trunk_model"],
-                    "outputs": ["out/head_model", "out/trunk_model"],
+                    "inputs": [{"id": "in/head_model", "kind": "model"}, {"id": "in/trunk_model", "kind": "model"}],
+                    "outputs": [{"id": "out/head_model", "kind": "model"}, {"id": "out/trunk_model", "kind": "model"}],
                 },
                 {
                     "key": str(aggregate_task.key),
@@ -116,8 +117,8 @@ class ComputePlanGraphViewTests(APITestCase):
                     "worker": "MyOrg1MSP",
                     "status": "STATUS_TODO",
                     "category": "TASK_AGGREGATE",
-                    "inputs": ["in/models[]"],
-                    "outputs": ["out/model"],
+                    "inputs": [{"id": "in/models[]", "kind": "model"}],
+                    "outputs": [{"id": "out/model", "kind": "model"}],
                 },
             ],
             "edges": [

--- a/backend/api/tests/views/test_views_compute_plan_graph.py
+++ b/backend/api/tests/views/test_views_compute_plan_graph.py
@@ -72,7 +72,6 @@ class ComputePlanGraphViewTests(APITestCase):
             compute_plan, algo=algo, category=ComputeTask.Category.TASK_AGGREGATE, parent_tasks=[composite_task.key]
         )
 
-        self.maxDiff = None
         expected_results = {
             "tasks": [
                 {

--- a/backend/api/views/compute_plan_graph.py
+++ b/backend/api/views/compute_plan_graph.py
@@ -21,7 +21,10 @@ logger = structlog.get_logger(__name__)
 TASK_CATEGORY_INPUTS = {
     ComputeTask.Category.TASK_TRAIN: [{"id": "in/model", "kind": "model"}],
     ComputeTask.Category.TASK_TEST: [{"id": "in/predictions", "kind": "model"}],
-    ComputeTask.Category.TASK_COMPOSITE: [{"id": "in/head_model", "kind": "model"}, {"id": "in/trunk_model", "kind": "model"}],
+    ComputeTask.Category.TASK_COMPOSITE: [
+        {"id": "in/head_model", "kind": "model"},
+        {"id": "in/trunk_model", "kind": "model"},
+    ],
     ComputeTask.Category.TASK_AGGREGATE: [{"id": "in/models[]", "kind": "model"}],
     ComputeTask.Category.TASK_PREDICT: [{"id": "in/tested_model", "kind": "model"}],
 }
@@ -29,7 +32,10 @@ TASK_CATEGORY_INPUTS = {
 TASK_CATEGORY_OUTPUTS = {
     ComputeTask.Category.TASK_TRAIN: [{"id": "out/model", "kind": "model"}],
     ComputeTask.Category.TASK_TEST: [{"id": "out/perf", "kind": "performance"}],
-    ComputeTask.Category.TASK_COMPOSITE: [{"id": "out/head_model", "kind": "model"}, {"id": "out/trunk_model", "kind": "model"}],
+    ComputeTask.Category.TASK_COMPOSITE: [
+        {"id": "out/head_model", "kind": "model"},
+        {"id": "out/trunk_model", "kind": "model"},
+    ],
     ComputeTask.Category.TASK_AGGREGATE: [{"id": "out/model", "kind": "model"}],
     ComputeTask.Category.TASK_PREDICT: [{"id": "out/predictions", "kind": "model"}],
 }
@@ -47,7 +53,7 @@ def _get_task_outputs(category):
 
 def _get_target_input(edge):
     target_category = edge.get("target_task_category")
-    inputs = [input['id'] for input in TASK_CATEGORY_INPUTS.get(target_category, [])]
+    inputs = [input["id"] for input in TASK_CATEGORY_INPUTS.get(target_category, [])]
     if TASK_CATEGORY_INPUTS.get(target_category) is None:
         raise Exception(
             (

--- a/backend/api/views/compute_plan_graph.py
+++ b/backend/api/views/compute_plan_graph.py
@@ -92,13 +92,12 @@ def get_cp_graph(request, compute_plan_pk):
     """Return a workflow graph for each task of the computeplan"""
     validate_key(compute_plan_pk)
 
-    tasks = ComputeTask.objects.filter(compute_plan__key=compute_plan_pk, channel=get_channel_name(request)).prefetch_related("algo").values(
+    tasks = ComputeTask.objects.filter(compute_plan__key=compute_plan_pk, channel=get_channel_name(request)).values(
         "key",
         "rank",
         "worker",
         "status",
         "category",
-        "algo"
     )
 
     # Set a task limitation for performances issues

--- a/backend/api/views/compute_plan_graph.py
+++ b/backend/api/views/compute_plan_graph.py
@@ -19,19 +19,19 @@ Field.register_lookup(Any)
 logger = structlog.get_logger(__name__)
 
 TASK_CATEGORY_INPUTS = {
-    ComputeTask.Category.TASK_TRAIN: ["in/model"],
-    ComputeTask.Category.TASK_TEST: ["in/predictions"],
-    ComputeTask.Category.TASK_COMPOSITE: ["in/head_model", "in/trunk_model"],
-    ComputeTask.Category.TASK_AGGREGATE: ["in/models[]"],
-    ComputeTask.Category.TASK_PREDICT: ["in/tested_model"],
+    ComputeTask.Category.TASK_TRAIN: [{"id": "in/model", "kind": "model"}],
+    ComputeTask.Category.TASK_TEST: [{"id": "in/predictions", "kind": "model"}],
+    ComputeTask.Category.TASK_COMPOSITE: [{"id": "in/head_model", "kind": "model"}, {"id": "in/trunk_model", "kind": "model"}],
+    ComputeTask.Category.TASK_AGGREGATE: [{"id": "in/models[]", "kind": "model"}],
+    ComputeTask.Category.TASK_PREDICT: [{"id": "in/tested_model", "kind": "model"}],
 }
 
 TASK_CATEGORY_OUTPUTS = {
-    ComputeTask.Category.TASK_TRAIN: ["out/model"],
-    ComputeTask.Category.TASK_TEST: [],
-    ComputeTask.Category.TASK_COMPOSITE: ["out/head_model", "out/trunk_model"],
-    ComputeTask.Category.TASK_AGGREGATE: ["out/model"],
-    ComputeTask.Category.TASK_PREDICT: ["out/predictions"],
+    ComputeTask.Category.TASK_TRAIN: [{"id": "out/model", "kind": "model"}],
+    ComputeTask.Category.TASK_TEST: [{"id": "out/perf", "kind": "performance"}],
+    ComputeTask.Category.TASK_COMPOSITE: [{"id": "out/head_model", "kind": "model"}, {"id": "out/trunk_model", "kind": "model"}],
+    ComputeTask.Category.TASK_AGGREGATE: [{"id": "out/model", "kind": "model"}],
+    ComputeTask.Category.TASK_PREDICT: [{"id": "out/predictions", "kind": "model"}],
 }
 
 MAX_TASKS_DISPLAYED = 1000
@@ -47,7 +47,7 @@ def _get_task_outputs(category):
 
 def _get_target_input(edge):
     target_category = edge.get("target_task_category")
-    inputs = TASK_CATEGORY_INPUTS.get(target_category, [])
+    inputs = [input['id'] for input in TASK_CATEGORY_INPUTS.get(target_category, [])]
     if TASK_CATEGORY_INPUTS.get(target_category) is None:
         raise Exception(
             (
@@ -68,7 +68,7 @@ def _get_target_input(edge):
 
 def _get_source_output(edge):
     source_category = edge.get("source_task_category")
-    outputs = TASK_CATEGORY_OUTPUTS.get(source_category, [])
+    outputs = [output["id"] for output in TASK_CATEGORY_OUTPUTS.get(source_category, [])]
     if TASK_CATEGORY_OUTPUTS.get(source_category) is None:
         raise Exception(
             (
@@ -92,12 +92,13 @@ def get_cp_graph(request, compute_plan_pk):
     """Return a workflow graph for each task of the computeplan"""
     validate_key(compute_plan_pk)
 
-    tasks = ComputeTask.objects.filter(compute_plan__key=compute_plan_pk, channel=get_channel_name(request)).values(
+    tasks = ComputeTask.objects.filter(compute_plan__key=compute_plan_pk, channel=get_channel_name(request)).prefetch_related("algo").values(
         "key",
         "rank",
         "worker",
         "status",
         "category",
+        "algo"
     )
 
     # Set a task limitation for performances issues


### PR DESCRIPTION
[Asana card](https://app.asana.com/0/1200346939311555/1203023779458048/f)

## Description
This simple PR adds the `kind` for each task's input and output.
This is needed for the frontend to be able to compute a proper graph layout, without relying on the task categories.
Note: Internally the input and output are still made up based on the categories and an hardcoded logic. This will be changed in a later PR.

⚠️ This is an API BREAKING CHANGE (See changes below)
frontend and substra needs to be updated. Here are the companion PRs:
- [frontend](https://github.com/Substra/substra-frontend/pull/114)
- ~~substra~~: Not impacted

Response before:
 ```
       {
            "key": "c1d5dc97-327a-4063-a3a3-a5388cfedee1",
            "rank": 3,
            "worker": "MyOrg1MSP",
            "status": "STATUS_DONE",
            "category": "TASK_PREDICT",
            "inputs": [
                "in/tested_model"
            ],
            "outputs": [
                "out/predictions"
            ]
        }
```

new response:
```
        {
            "key": "c1d5dc97-327a-4063-a3a3-a5388cfedee1",
            "rank": 3,
            "worker": "MyOrg1MSP",
            "status": "STATUS_DONE",
            "category": "TASK_PREDICT",
            "inputs": [
                {
                    "id": "in/tested_model",
                    "kind": "model"
                }
            ],
            "outputs": [
                {
                    "id": "out/predictions",
                    "kind": "model"
                }
            ]
        }
```
