### PR TITLE
fix: Allow to set CSRF_TRUSTED_ORIGINS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - output identifier add in metric response object in `compute_plan perf` view.
 - Prevent use of `__` in asset metadata keys
 - Task input asset
+- Accept `CSRF_TRUSTED_ORIGINS` env var as settings option
 
 ### Fixed
 
 - Bug in migration 0028_data_migration_compute_task_output.
-
 
 ### Removed
 

--- a/backend/backend/settings/common.py
+++ b/backend/backend/settings/common.py
@@ -160,6 +160,7 @@ WSGI_APPLICATION = "backend.wsgi.application"
 SECURE_CONTENT_TYPE_NOSNIFF = True
 SESSION_COOKIE_HTTPONLY = True
 CSRF_COOKIE_HTTPONLY = True
+# @CSRF_TRUSTED_ORIGINS: A list of origins that are allowed to use unsafe HTTP methods
 CSRF_TRUSTED_ORIGINS = json.loads(os.environ.get("CSRF_TRUSTED_ORIGINS", "[]"))
 
 # Database

--- a/backend/backend/settings/common.py
+++ b/backend/backend/settings/common.py
@@ -160,6 +160,7 @@ WSGI_APPLICATION = "backend.wsgi.application"
 SECURE_CONTENT_TYPE_NOSNIFF = True
 SESSION_COOKIE_HTTPONLY = True
 CSRF_COOKIE_HTTPONLY = True
+CSRF_TRUSTED_ORIGINS = json.loads(os.environ.get("CSRF_TRUSTED_ORIGINS", "[]"))
 
 # Database
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -30,6 +30,7 @@ Accepted true values for `bool` are: `1`, `ON`, `On`, `on`, `T`, `t`, `TRUE`, `T
 | string | `COMPUTE_POD_RUN_AS_GROUP` | nil |  |
 | string | `COMPUTE_POD_RUN_AS_USER` | nil |  |
 | int | `COMPUTE_POD_STARTUP_TIMEOUT_SECONDS` | `300` |  |
+| json | `CSRF_TRUSTED_ORIGINS` | `[]` |  |
 | int | `DATA_UPLOAD_MAX_SIZE` | `1073741824` (`1024 * 1024 * 1024`) | bytes |
 | bool | `DEBUG_KEEP_POD_AND_DIRS` | `False` |  |
 | bool | `DJANGO_LOG_SQL_QUERIES` | `True` |  |

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -30,7 +30,7 @@ Accepted true values for `bool` are: `1`, `ON`, `On`, `on`, `T`, `t`, `TRUE`, `T
 | string | `COMPUTE_POD_RUN_AS_GROUP` | nil |  |
 | string | `COMPUTE_POD_RUN_AS_USER` | nil |  |
 | int | `COMPUTE_POD_STARTUP_TIMEOUT_SECONDS` | `300` |  |
-| json | `CSRF_TRUSTED_ORIGINS` | `[]` |  |
+| json | `CSRF_TRUSTED_ORIGINS` | `[]` | A list of origins that are allowed to use unsafe HTTP methods |
 | int | `DATA_UPLOAD_MAX_SIZE` | `1073741824` (`1024 * 1024 * 1024`) | bytes |
 | bool | `DEBUG_KEEP_POD_AND_DIRS` | `False` |  |
 | bool | `DJANGO_LOG_SQL_QUERIES` | `True` |  |

--- a/examples/values/backend-org-1.yaml
+++ b/examples/values/backend-org-1.yaml
@@ -2,6 +2,7 @@ settings: dev
 config:
   TOKEN_STRATEGY: "reuse"
   CORS_ORIGIN_WHITELIST: '["http://substra-frontend.org-1.com", "http://substra-frontend.org-1.com:3000", "http://substra-frontend.org-1.com:3001"]'
+  CSRF_TRUSTED_ORIGINS: '["http://substra-frontend.org-1.com", "http://substra-frontend.org-1.com:3000", "http://substra-frontend.org-1.com:3001"]'
   CORS_ALLOW_CREDENTIALS: "true"
   ALLOWED_HOSTS: '[".org-1.com", ".org-1", ".org-1.svc.cluster.local"]'
   DEFAULT_THROTTLE_RATES: "120"

--- a/examples/values/backend-org-2.yaml
+++ b/examples/values/backend-org-2.yaml
@@ -2,6 +2,7 @@ settings: dev
 config:
   TOKEN_STRATEGY: "reuse"
   CORS_ORIGIN_WHITELIST: '["http://substra-frontend.org-2.com", "http://substra-frontend.org-2.com:3000", "http://substra-frontend.org-2.com:3001"]'
+  CSRF_TRUSTED_ORIGINS: '["http://substra-frontend.org-2.com", "http://substra-frontend.org-2.com:3000", "http://substra-frontend.org-2.com:3001"]'
   CORS_ALLOW_CREDENTIALS: "true"
   ALLOWED_HOSTS: '[".org-2.com", ".org-2", ".org-2.svc.cluster.local"]'
   DEFAULT_THROTTLE_RATES: "120"


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->
The default value was not compatible with a locally deployed frontend.
See https://github.com/adamchainz/django-cors-headers#csrf-integration

<!-- Please include a summary of your changes. -->
This change is quite minimal: the setting is created from env var.

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->
Locally, with this change I'm able to login through the frontend.

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
