### PR TITLE
fix: set ingressClassName correctly on the Ingress resource

### DIFF
--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 22.1.3
+
+### Fixed
+- ingressClassName is now set correctly on the ingress.
+
 ## 22.1.2
 
 ### Changed

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: substra-backend
 home: https://github.com/Substra
-version: 22.1.2
+version: 22.1.3
 appVersion: 0.31.0
 kubeVersion: ">= 1.19.0-0"
 description: Main package for Substra

--- a/charts/substra-backend/templates/ingress.yaml
+++ b/charts/substra-backend/templates/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end }}
 spec:
   {{- if .Values.server.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.server.ingressClassName | quote }}
+  ingressClassName: {{ .Values.server.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
     {{- if .Values.server.ingress.hostname }}


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->

<!-- Please include a summary of your changes. -->
The `server.ingress.ingressClassName` value was not used properly by the Chart.
Now if you set the ingress class name in your Values your ingress will have the right class.

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->
N/A

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [x] documentation was updated
