### PR TITLE
fix: api migration 028

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - output identifier add in metric response object in `compute_plan perf` view.
 - Prevent use of `__` in asset metadata keys
 
+### Fixed
+
+- Bug in migration 0028_data_migration_compute_task_output.
+
+
 ### Removed
 
 - BREAKING: model categories


### PR DESCRIPTION
Signed-off-by: Kelvin Moutet <kelvin.moutet@owkin.com>

## Description
When we do an update of substra-backend with data populated before api migrations 028 we face this issue 

```python
Operations to perform:
  Apply all migrations: auth, authtoken, contenttypes, django_celery_results, localrep, organization, sessions, sites, substrapp, token_blacklist, users
Running migrations:
Traceback (most recent call last):
  File "/usr/src/app/manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.9/site-packages/django/core/management/__init__.py", line 446, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.9/site-packages/django/core/management/__init__.py", line 440, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.9/site-packages/django/core/management/base.py", line 414, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.9/site-packages/django/core/management/base.py", line 460, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.9/site-packages/django/core/management/base.py", line 98, in wrapped
    res = handle_func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/core/management/commands/migrate.py", line 290, in handle
    post_migrate_state = executor.migrate(
  File "/usr/local/lib/python3.9/site-packages/django/db/migrations/executor.py", line 131, in migrate
    state = self._migrate_all_forwards(
  File "/usr/local/lib/python3.9/site-packages/django/db/migrations/executor.py", line 163, in _migrate_all_forwards
    state = self.apply_migration(
  File "/usr/local/lib/python3.9/site-packages/django/db/migrations/executor.py", line 248, in apply_migration
    state = migration.apply(state, schema_editor)
  File "/usr/local/lib/python3.9/site-packages/django/db/migrations/migration.py", line 131, in apply
    operation.database_forwards(
  File "/usr/local/lib/python3.9/site-packages/django/db/migrations/operations/special.py", line 193, in database_forwards
    self.code(from_state.apps, schema_editor)
  File "/usr/src/app/localrep/migrations/0028_data_migration_compute_task_output.py", line 19, in add_missing_compute_task_outputs
    if task.category in [compute_task_model.Category.TASK_TRAIN, compute_task_model.Category.TASK_AGGREGATE]:
AttributeError: type object 'ComputeTask' has no attribute 'Category'
Stream closed EOF for org-1/backend-org-1-substra-backend-server-68b879d5bc-t4fzq (init-migrate)
```
It’s linked to https://docs.djangoproject.com/en/4.1/topics/migrations/#historical-models
And 
https://stackoverflow.com/a/59142840  suggests that we cannot use attributes from a model based on its historical versions

<!-- Please reference issue if any. -->

<!-- Please include a summary of your changes. -->

## How has this been tested?
Deploy Substra platform 0.17.1, populate it, try to update to Substra 0.21.0 and upper

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
