### PR TITLE
fix: generate fixtures command after removing algo category

### DIFF
--- a/backend/api/management/commands/generate_fixtures.py
+++ b/backend/api/management/commands/generate_fixtures.py
@@ -4,7 +4,6 @@ from django.core.management.base import BaseCommand
 from api.models import ComputePlan
 from api.models import ComputeTask
 from api.tests import asset_factory as factory
-from substrapp.tests.common import AlgoCategory
 
 
 class Command(BaseCommand):
@@ -14,25 +13,21 @@ class Command(BaseCommand):
         simple_algo = factory.create_algo(
             inputs=factory.build_algo_inputs(["datasamples", "opener", "model"]),
             outputs=factory.build_algo_outputs(["model"]),
-            category=AlgoCategory.simple,
             name="simple algo",
         )
         aggregate_algo = factory.create_algo(
             inputs=factory.build_algo_inputs(["model"]),
             outputs=factory.build_algo_outputs(["model"]),
-            category=AlgoCategory.aggregate,
             name="aggregate",
         )
         composite_algo = factory.create_algo(
             inputs=factory.build_algo_inputs(["datasamples", "opener", "local", "shared"]),
             outputs=factory.build_algo_outputs(["local", "shared"]),
-            category=AlgoCategory.composite,
             name="composite",
         )
         metric_algo = factory.create_algo(
             inputs=factory.build_algo_inputs(["datasamples", "opener", "predictions"]),
             outputs=factory.build_algo_outputs(["performance"]),
-            category=AlgoCategory.metric,
             name="metric",
         )
 


### PR DESCRIPTION
Signed-off-by: Serge Bouchut <serge.bouchut@owkin.com>

## Description

Fix the generate fixures command which break the CI following this [PR](https://github.com/Substra/substra-backend/pull/487).

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
