### PR TITLE
chore: enable redis persistence

### DIFF
--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 22.2.0
+
+### Change
+- Enable Redis persistence using append-only file (AOF)
+
 ## 22.1.3
 
 ### Fixed

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: substra-backend
 home: https://github.com/Substra
-version: 22.1.3
+version: 22.2.0
 appVersion: 0.31.0
 kubeVersion: ">= 1.19.0-0"
 description: Main package for Substra

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -667,12 +667,17 @@ redis:
     password: redis
   master:
     persistence:
-      enabled: false
+      enabled: true
     service:
       ports:
         redis: 6379
   replica:
     replicaCount: 0
+  commonConfiguration: |-
+    # Enable AOF https://redis.io/topics/persistence
+    appendonly yes
+    # Disable RDB persistence since AOF persistence is enabled
+    save ""
 
 ## @skip docker-registry
 ##

--- a/examples/values/backend-org-1.yaml
+++ b/examples/values/backend-org-1.yaml
@@ -14,6 +14,11 @@ postgresql:
     persistence:
       enabled: false
 
+redis:
+  master:
+    persistence:
+      enabled: false
+
 docker-registry:
   service:
     type: NodePort

--- a/examples/values/backend-org-2.yaml
+++ b/examples/values/backend-org-2.yaml
@@ -14,6 +14,11 @@ postgresql:
     persistence:
       enabled: false
 
+redis:
+  master:
+    persistence:
+      enabled: false
+
 docker-registry:
   service:
     type: NodePort


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->

<!-- Please include a summary of your changes. -->

Previously, the Redis data of the compute engine was not stored in a Persistent Volume. Hence, in the event of a Redis outage, tasks could disappear without ever being processed by the workers. **This PR updates the Helm chart so that Redis data are written on a Persistent Volume.**

Moreover, by default, Redis uses snapshot-based persistence (RDB). The compute engine use case requires better durability guarantees (and not necessarily a high throughput). **This PR updates the Redis config, so that [append-only file based persistence is used](https://redis.io/docs/manual/persistence/)**.

_Note: In the development environment, the data is not persisted in a persistent volume, similar to what is done with PostgreSQL data._

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

- in a local dev environment, by checking that Persistent Volume and PVC are created
- [substra-tests](https://github.com/owkin/substra-ci/actions/runs/3149772938/jobs/5121781586)

## Checklist

- [X] [changelog](../CHANGELOG.md) was updated with notable changes
