### PR TITLE
feat: new endpoints to list input/output assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Compute task outputs/inputs valid storage address.
 
+### Added
+
+- Endpoints to list task input/output assets
+
 ## [0.32.0] 2022-10-03
 
 ### Changed

--- a/backend/api/serializers/__init__.py
+++ b/backend/api/serializers/__init__.py
@@ -1,5 +1,7 @@
 from .algo import AlgoSerializer
 from .computeplan import ComputePlanSerializer
+from .computetask import ComputeTaskInputAssetSerializer
+from .computetask import ComputeTaskOutputAssetSerializer
 from .computetask import ComputeTaskSerializer
 from .computetask import LegacyComputeTaskSerializer
 from .computetask import LegacyComputeTaskWithRelationshipsSerializer
@@ -17,6 +19,8 @@ __all__ = [
     "AlgoSerializer",
     "ComputePlanSerializer",
     "ComputeTaskSerializer",
+    "ComputeTaskInputAssetSerializer",
+    "ComputeTaskOutputAssetSerializer",
     "LegacyComputeTaskSerializer",
     "LegacyComputeTaskWithRelationshipsSerializer",
     "DataManagerSerializer",

--- a/backend/api/serializers/computetask.py
+++ b/backend/api/serializers/computetask.py
@@ -110,12 +110,14 @@ class ComputeTaskOutputSerializer(serializers.ModelSerializer, SafeSerializerMix
 
 class ComputeTaskInputAssetSerializer(serializers.ModelSerializer, SafeSerializerMixin):
     identifier = serializers.SerializerMethodField(source="*", read_only=True)
+    kind = serializers.CharField(source="asset_kind", read_only=True)
     asset = serializers.SerializerMethodField(source="*", read_only=True)
 
     class Meta:
         model = ComputeTaskInputAsset
         fields = [
             "identifier",
+            "kind",
             "asset",
         ]
 
@@ -136,12 +138,14 @@ class ComputeTaskInputAssetSerializer(serializers.ModelSerializer, SafeSerialize
 
 class ComputeTaskOutputAssetSerializer(serializers.ModelSerializer, SafeSerializerMixin):
     identifier = serializers.SerializerMethodField(source="*", read_only=True)
+    kind = serializers.CharField(source="asset_kind", read_only=True)
     asset = serializers.SerializerMethodField(source="*", read_only=True)
 
     class Meta:
         model = ComputeTaskOutputAsset
         fields = [
             "identifier",
+            "kind",
             "asset",
         ]
 

--- a/backend/api/tests/views/test_views_computetask.py
+++ b/backend/api/tests/views/test_views_computetask.py
@@ -2582,10 +2582,12 @@ class GenericTaskViewTests(ComputeTaskViewTests):
         expected_results = [
             {
                 "identifier": "datasamples",
+                "kind": "ASSET_DATA_SAMPLE",
                 "asset": self.data_sample_data,
             },
             {
                 "identifier": "opener",
+                "kind": "ASSET_DATA_MANAGER",
                 "asset": self.data_manager_data,
             },
         ]
@@ -2600,6 +2602,7 @@ class GenericTaskViewTests(ComputeTaskViewTests):
         expected_results = [
             {
                 "identifier": "model",
+                "kind": "ASSET_MODEL",
                 "asset": self.train_model_data,
             },
         ]

--- a/backend/api/views/computetask.py
+++ b/backend/api/views/computetask.py
@@ -279,12 +279,13 @@ class ComputeTaskViewSetConfig:
     def input_assets(self, request, pk):
         input_assets = ComputeTaskInputAsset.objects.filter(task_input__task_id=pk).order_by("task_input__position")
 
+        context = {"request": request}
         page = self.paginate_queryset(input_assets)
         if page is not None:
-            serializer = ComputeTaskInputAssetSerializer(page, many=True)
+            serializer = ComputeTaskInputAssetSerializer(page, many=True, context=context)
             return self.get_paginated_response(serializer.data)
 
-        serializer = ComputeTaskInputAssetSerializer(input_assets, many=True)
+        serializer = ComputeTaskInputAssetSerializer(input_assets, many=True, context=context)
         return ApiResponse(serializer.data)
 
     @action(detail=True, url_name="output_assets")
@@ -293,12 +294,13 @@ class ComputeTaskViewSetConfig:
             "task_output__identifier"
         )
 
+        context = {"request": request}
         page = self.paginate_queryset(output_assets)
         if page is not None:
-            serializer = ComputeTaskOutputAssetSerializer(page, many=True)
+            serializer = ComputeTaskOutputAssetSerializer(page, many=True, context=context)
             return self.get_paginated_response(serializer.data)
 
-        serializer = ComputeTaskOutputAssetSerializer(output_assets, many=True)
+        serializer = ComputeTaskOutputAssetSerializer(output_assets, many=True, context=context)
         return ApiResponse(serializer.data)
 
     def get_queryset(self):

--- a/backend/api/views/computetask.py
+++ b/backend/api/views/computetask.py
@@ -277,7 +277,9 @@ class ComputeTaskViewSetConfig:
 
     @action(detail=True, url_name="input_assets")
     def input_assets(self, request, pk):
-        input_assets = ComputeTaskInputAsset.objects.filter(task_input__task_id=pk).order_by("task_input__position")
+        input_assets = ComputeTaskInputAsset.objects.filter(task_input__task_id=pk).order_by(
+            "task_input__identifier", "task_input__position"
+        )
 
         context = {"request": request}
         page = self.paginate_queryset(input_assets)

--- a/backend/api/views/computetask.py
+++ b/backend/api/views/computetask.py
@@ -21,6 +21,10 @@ from api.errors import AlreadyExistsError
 from api.errors import BadRequestError
 from api.models import ComputePlan
 from api.models import ComputeTask
+from api.models import ComputeTaskInputAsset
+from api.models import ComputeTaskOutputAsset
+from api.serializers import ComputeTaskInputAssetSerializer
+from api.serializers import ComputeTaskOutputAssetSerializer
 from api.serializers import ComputeTaskSerializer
 from api.serializers import LegacyComputeTaskSerializer
 from api.serializers import LegacyComputeTaskWithRelationshipsSerializer
@@ -270,6 +274,32 @@ class ComputeTaskViewSetConfig:
     @action(methods=["post"], detail=False, url_name="bulk_create")
     def bulk_create(self, request, *args, **kwargs):
         return task_bulk_create(request)
+
+    @action(detail=True, url_name="input_assets")
+    def input_assets(self, request, pk):
+        input_assets = ComputeTaskInputAsset.objects.filter(task_input__task_id=pk).order_by("task_input__position")
+
+        page = self.paginate_queryset(input_assets)
+        if page is not None:
+            serializer = ComputeTaskInputAssetSerializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = ComputeTaskInputAssetSerializer(input_assets, many=True)
+        return ApiResponse(serializer.data)
+
+    @action(detail=True, url_name="output_assets")
+    def output_assets(self, request, pk):
+        output_assets = ComputeTaskOutputAsset.objects.filter(task_output__task_id=pk).order_by(
+            "task_output__identifier"
+        )
+
+        page = self.paginate_queryset(output_assets)
+        if page is not None:
+            serializer = ComputeTaskOutputAssetSerializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = ComputeTaskOutputAssetSerializer(output_assets, many=True)
+        return ApiResponse(serializer.data)
 
     def get_queryset(self):
         queryset = (


### PR DESCRIPTION
Signed-off-by: Serge Bouchut <serge.bouchut@owkin.com>

## Description

New endpoints to list input/output assets.

The deprecated fields will be removed in #509, after the frontend is switched to the new endpoints.

```
GET /task/873ec870-54a6-46ad-a5f9-d3a509b1a22e/input_assets/

HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "count": 2,
    "next": null,
    "previous": null,
    "results": [
        {
            "identifier": "datasamples",
            "asset": {
                "creation_date": "2022-10-03T08:25:13.806075Z",
                "data_manager_keys": [
                    "c5120265-7a8d-4eb8-83c1-3e200c4c0bba"
                ],
                "key": "9db9231a-9b54-4e12-bcbf-c3802868d00f",
                "owner": "MyOrg1MSP",
                "test_only": false
            }
        },
        {
            "identifier": "opener",
            "asset": {
                "creation_date": "2022-10-03T08:25:13.797115Z",
                "description": {
                    "storage_address": "http://substra-backend.org-1.com:8000/data_manager/c5120265-7a8d-4eb8-83c1-3e200c4c0bba/description/",
                    "checksum": "dummy-checksum"
                },
                "key": "c5120265-7a8d-4eb8-83c1-3e200c4c0bba",
                "logs_permission": {
                    "authorized_ids": [
                        "MyOrg1MSP"
                    ],
                    "public": false
                },
                "metadata": {},
                "name": "datamanager",
                "opener": {
                    "storage_address": "http://substra-backend.org-1.com:8000/data_manager/c5120265-7a8d-4eb8-83c1-3e200c4c0bba/opener/",
                    "checksum": "dummy-checksum"
                },
                "owner": "MyOrg1MSP",
                "permissions": {
                    "download": {
                        "authorized_ids": [
                            "MyOrg1MSP"
                        ],
                        "public": false
                    },
                    "process": {
                        "authorized_ids": [
                            "MyOrg1MSP"
                        ],
                        "public": false
                    }
                },
                "type": "Test"
            }
        }
    ]
}
```

```
GET /task/873ec870-54a6-46ad-a5f9-d3a509b1a22e/output_assets/

HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "count": 1,
    "next": null,
    "previous": null,
    "results": [
        {
            "identifier": "model",
            "asset": {
                "address": {
                    "storage_address": "http://substra-backend.org-1.com:8000/model/9e12ec77-3da3-4cc8-bf33-024774b20987/file/",
                    "checksum": "dummy-checksum"
                },
                "compute_task_key": "873ec870-54a6-46ad-a5f9-d3a509b1a22e",
                "creation_date": "2022-10-03T08:25:14.080184Z",
                "key": "9e12ec77-3da3-4cc8-bf33-024774b20987",
                "owner": "MyOrg1MSP",
                "permissions": {
                    "download": {
                        "authorized_ids": [
                            "MyOrg1MSP"
                        ],
                        "public": false
                    },
                    "process": {
                        "authorized_ids": [
                            "MyOrg1MSP"
                        ],
                        "public": false
                    }
                }
            }
        }
    ]
}
```


## How has this been tested?

E2e tests not needed, existing endpoints not changed.

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
