### PR TITLE
docs: Remove RabbitMQ patch for Apple Silicon chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BREAKING: model categories
 - BREAKING: algo categories
+- Outdated information on patching RabbitMQ for Apple Silicon chips.
 
 ## [0.31.0] 2022-09-26
 

--- a/README.md
+++ b/README.md
@@ -241,5 +241,3 @@ sudo ln -s /Library/Developer/CommandLineTools/Library/Frameworks/Python3.framew
 ```
 
 2. Deploy with `skaffold run -p dev,arm64`
-
-3. Run patch `./examples/tools/patch-rabbitmq-arm64.sh`


### PR DESCRIPTION
## Description

Remove RabbitMQ patch references in changelog.

## How has this been tested?

None.

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes

