### PR TITLE
fix: compute task outputs/inputs valid storage address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Compute task outputs/inputs valid storage address.
+
 ## [0.32.0] 2022-10-03
 
 ### Changed

--- a/backend/api/serializers/computetask.py
+++ b/backend/api/serializers/computetask.py
@@ -59,12 +59,12 @@ class ComputeTaskInputSerializer(serializers.ModelSerializer, SafeSerializerMixi
         try:
             if task_input.asset.asset_kind == AlgoInput.Kind.ASSET_DATA_MANAGER:
                 data_manager = DataManager.objects.get(key=task_input.asset.asset_key)
-                data_manager_data = DataManagerSerializer(instance=data_manager).data
+                data_manager_data = DataManagerSerializer(context=self.context, instance=data_manager).data
                 data["addressable"] = data_manager_data["opener"]
                 data["permissions"] = data_manager_data["permissions"]
             elif task_input.asset.asset_kind == AlgoInput.Kind.ASSET_MODEL:
                 model = Model.objects.get(key=task_input.asset.asset_key)
-                model_data = ModelSerializer(instance=model).data
+                model_data = ModelSerializer(context=self.context, instance=model).data
                 data["addressable"] = model_data["address"]
                 data["permissions"] = model_data["permissions"]
         except ComputeTaskInputAsset.DoesNotExist:
@@ -90,7 +90,7 @@ class ComputeTaskOutputSerializer(serializers.ModelSerializer, SafeSerializerMix
         for output_asset in task_output.assets.all():
             if output_asset.asset_kind == AlgoOutput.Kind.ASSET_MODEL:
                 model = Model.objects.get(key=output_asset.asset_key)
-                data.append(ModelSerializer(instance=model).data)
+                data.append(ModelSerializer(context=self.context, instance=model).data)
             elif output_asset.asset_kind == AlgoOutput.Kind.ASSET_PERFORMANCE:
                 task_key, metric_key = output_asset.asset_key.split("|")
                 perf = Performance.objects.get(compute_task__key=task_key, metric__key=metric_key)


### PR DESCRIPTION
Signed-off-by: Serge Bouchut <serge.bouchut@owkin.com>

## Description

Fix storage address for compute task inputs/output.
The value is expected to be overwritten by the child serializer, (see [here](https://github.com/Substra/substra-backend/blob/main/backend/api/serializers/model.py#L40) for instance).
As child serializer is not directly set as an attribute to the parent serializer, the context is not automatically provided under the hood by DRF and we need to set it manually.

## How has this been tested?

Manual check via the DRF UI.

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
