### PR TITLE
feat: remove deprecated input output values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `IncomingOrganization` password hashed twice when hasher algorithm was updated ([#592](https://github.com/Substra/substra-backend/pull/592))
 
+### Removed
+
+- BREAKING: asset values in compute task inputs/outputs. ([#509](https://github.com/Substra/substra-backend/pull/509))
+
 ## [0.35.0](https://github.com/Substra/substra-backend/releases/tag/0.35.0) 2023-02-06
 
 ### Added

--- a/backend/api/events/sync.py
+++ b/backend/api/events/sync.py
@@ -25,7 +25,7 @@ from api.models import Function
 from api.models import Model
 from api.serializers import ChannelOrganizationSerializer
 from api.serializers import ComputePlanSerializer
-from api.serializers import ComputeTaskWithDetailsSerializer
+from api.serializers import ComputeTaskSerializer
 from api.serializers import DataManagerSerializer
 from api.serializers import DataSampleSerializer
 from api.serializers import FunctionSerializer
@@ -161,7 +161,7 @@ def _create_computetask(
             api_data["logs_address"] = failure_report["logs_address"]
         if "owner" in failure_report:
             api_data["logs_owner"] = failure_report["owner"]
-    serializer = ComputeTaskWithDetailsSerializer(data=api_data)
+    serializer = ComputeTaskSerializer(data=api_data)
     try:
         serializer.save_if_not_exists()
     except AlreadyExistsError:

--- a/backend/api/serializers/__init__.py
+++ b/backend/api/serializers/__init__.py
@@ -2,7 +2,6 @@ from .computeplan import ComputePlanSerializer
 from .computetask import ComputeTaskInputAssetSerializer
 from .computetask import ComputeTaskOutputAssetSerializer
 from .computetask import ComputeTaskSerializer
-from .computetask import ComputeTaskWithDetailsSerializer
 from .datamanager import DataManagerSerializer
 from .datamanager import DataManagerWithRelationsSerializer
 from .datasample import DataSampleSerializer
@@ -18,7 +17,6 @@ __all__ = [
     "FunctionSerializer",
     "ComputePlanSerializer",
     "ComputeTaskSerializer",
-    "ComputeTaskWithDetailsSerializer",
     "ComputeTaskInputAssetSerializer",
     "ComputeTaskOutputAssetSerializer",
     "DataManagerSerializer",

--- a/backend/api/serializers/computetask.py
+++ b/backend/api/serializers/computetask.py
@@ -151,6 +151,8 @@ class ComputeTaskSerializer(serializers.ModelSerializer, SafeSerializerMixin):
             "tag",
             "worker",
             "duration",
+            "inputs",
+            "outputs",
         ]
 
     def to_representation(self, instance):
@@ -164,6 +166,8 @@ class ComputeTaskSerializer(serializers.ModelSerializer, SafeSerializerMixin):
 
         # replace storage addresses
         self._replace_storage_addresses(data)
+
+        data["outputs"] = {_output.pop("identifier"): _output for _output in data["outputs"]}
 
         return data
 
@@ -180,25 +184,6 @@ class ComputeTaskSerializer(serializers.ModelSerializer, SafeSerializerMixin):
             task["function"]["function"]["storage_address"] = request.build_absolute_uri(
                 reverse("api:function-file", args=[task["function"]["key"]])
             )
-
-
-class ComputeTaskWithDetailsSerializer(ComputeTaskSerializer):
-    inputs = ComputeTaskInputSerializer(many=True)
-    outputs = ComputeTaskOutputSerializer(many=True)
-
-    class Meta:
-        model = ComputeTask
-        fields = ComputeTaskSerializer.Meta.fields + [
-            "inputs",
-            "outputs",
-        ]
-
-    def to_representation(self, instance):
-        data = super().to_representation(instance)
-
-        data["outputs"] = {_output.pop("identifier"): _output for _output in data["outputs"]}
-
-        return data
 
     @transaction.atomic
     def create(self, validated_data):

--- a/backend/api/serializers/computetask.py
+++ b/backend/api/serializers/computetask.py
@@ -131,6 +131,8 @@ class ComputeTaskSerializer(serializers.ModelSerializer, SafeSerializerMixin):
     channel = serializers.ChoiceField(choices=get_channel_choices(), write_only=True)
 
     duration = serializers.IntegerField(read_only=True)
+    inputs = ComputeTaskInputSerializer(many=True)
+    outputs = ComputeTaskOutputSerializer(many=True)
 
     class Meta:
         model = ComputeTask

--- a/backend/api/tests/views/test_views_computetask.py
+++ b/backend/api/tests/views/test_views_computetask.py
@@ -101,45 +101,30 @@ class ComputeTaskViewTests(APITestCase):
             "parent_task_key": None,
             "parent_task_output_identifier": None,
         }
-        self.opener_input_with_value = {**self.opener_input}
-        self.opener_input_with_value["addressable"] = self.data_manager_data["opener"]
-        self.opener_input_with_value["permissions"] = self.data_manager_data["permissions"]
         self.model_input = {
             "identifier": "model",
             "asset_key": None,
             "parent_task_key": str(self.done_task.key),
             "parent_task_output_identifier": "model",
         }
-        self.model_input_with_value = {**self.model_input}
-        self.model_input_with_value["addressable"] = self.model_data["address"]
-        self.model_input_with_value["permissions"] = self.model_data["permissions"]
         self.models_input = {
             "identifier": "models",
             "asset_key": None,
             "parent_task_key": str(self.done_task.key),
             "parent_task_output_identifier": "model",
         }
-        self.models_input_with_value = {**self.models_input}
-        self.models_input_with_value["addressable"] = self.model_data["address"]
-        self.models_input_with_value["permissions"] = self.model_data["permissions"]
         self.shared_input = {
             "identifier": "shared",
             "asset_key": None,
             "parent_task_key": str(self.done_task.key),
             "parent_task_output_identifier": "model",
         }
-        self.shared_input_with_value = {**self.shared_input}
-        self.shared_input_with_value["addressable"] = self.model_data["address"]
-        self.shared_input_with_value["permissions"] = self.model_data["permissions"]
         self.predictions_input = {
             "identifier": "predictions",
             "asset_key": None,
             "parent_task_key": str(self.done_task.key),
             "parent_task_output_identifier": "model",
         }
-        self.predictions_input_with_value = {**self.predictions_input}
-        self.predictions_input_with_value["addressable"] = self.model_data["address"]
-        self.predictions_input_with_value["permissions"] = self.model_data["permissions"]
 
     def prepare_outputs(self):
         self.model_output = {
@@ -148,17 +133,13 @@ class ComputeTaskViewTests(APITestCase):
                 "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
             },
             "transient": False,
-            "value": None,
         }
-        self.model_output_with_value = {**self.model_output}
-        self.model_output_with_value["value"] = self.model_data
         self.predictions_output = {
             "permissions": {
                 "process": {"public": False, "authorized_ids": ["MyOrg1MSP"]},
                 "download": {"public": False, "authorized_ids": ["MyOrg1MSP"]},
             },
             "transient": False,
-            "value": None,
         }
         self.performance_output = {
             "permissions": {
@@ -166,7 +147,6 @@ class ComputeTaskViewTests(APITestCase):
                 "process": {"authorized_ids": ["MyOrg1MSP"], "public": False},
             },
             "transient": False,
-            "value": None,
         }
 
     def tearDown(self):
@@ -254,8 +234,8 @@ class TaskBulkCreateViewTests(ComputeTaskViewTests):
                 "worker": "MyOrg1MSP",
                 "inputs": [
                     self.datasamples_input,
-                    self.opener_input_with_value,
-                    self.model_input_with_value,
+                    self.opener_input,
+                    self.model_input,
                 ],
                 "outputs": {
                     "model": self.model_output,

--- a/backend/api/tests/views/test_views_computetask.py
+++ b/backend/api/tests/views/test_views_computetask.py
@@ -556,7 +556,6 @@ class GenericTaskViewTests(ComputeTaskViewTests):
         # this should be enough to guarantee that there will only be one matching task
         params = urlencode({"match": key[19:]})
         response = self.client.get(f"{self.url}?{params}", **self.extra)
-        print(self.list_expected_results[0].get("function"))
         self.assertDictEqual(
             response.json(), {"count": 1, "next": None, "previous": None, "results": self.list_expected_results[:1]}
         )

--- a/backend/api/tests/views/test_views_computetask.py
+++ b/backend/api/tests/views/test_views_computetask.py
@@ -260,6 +260,7 @@ class GenericTaskViewTests(ComputeTaskViewTests):
     def setUp(self):
         super().setUp()
         self.url = reverse("api:task-list")
+        self.maxDiff = None
 
         todo_task = self.compute_tasks[ComputeTask.Status.STATUS_TODO]
         waiting_task = self.compute_tasks[ComputeTask.Status.STATUS_WAITING]
@@ -311,6 +312,8 @@ class GenericTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 0,  # because start_date is None
+                "inputs": [self.datasamples_input, self.opener_input],
+                "outputs": {"model": self.model_output},
             },
             {
                 "key": str(waiting_task.key),
@@ -331,6 +334,8 @@ class GenericTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 0,  # because start_date is None
+                "inputs": [self.datasamples_input, self.opener_input],
+                "outputs": {"model": self.model_output},
             },
             {
                 "key": str(doing_task.key),
@@ -351,6 +356,8 @@ class GenericTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 3600,
+                "inputs": [self.datasamples_input, self.opener_input],
+                "outputs": {"model": self.model_output},
             },
             {
                 "key": str(done_task.key),
@@ -371,6 +378,8 @@ class GenericTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 3600,
+                "inputs": [self.datasamples_input, self.opener_input],
+                "outputs": {"model": self.model_output},
             },
             {
                 "key": str(failed_task.key),
@@ -391,6 +400,8 @@ class GenericTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 3600,
+                "inputs": [self.datasamples_input, self.opener_input],
+                "outputs": {"model": self.model_output},
             },
             {
                 "key": str(canceled_task.key),
@@ -411,6 +422,8 @@ class GenericTaskViewTests(ComputeTaskViewTests):
                     "authorized_ids": ["MyOrg1MSP"],
                 },
                 "duration": 3600,
+                "inputs": [self.datasamples_input, self.opener_input],
+                "outputs": {"model": self.model_output},
             },
         ]
 
@@ -543,7 +556,8 @@ class GenericTaskViewTests(ComputeTaskViewTests):
         # this should be enough to guarantee that there will only be one matching task
         params = urlencode({"match": key[19:]})
         response = self.client.get(f"{self.url}?{params}", **self.extra)
-        self.assertEqual(
+        print(self.list_expected_results[0].get("function"))
+        self.assertDictEqual(
             response.json(), {"count": 1, "next": None, "previous": None, "results": self.list_expected_results[:1]}
         )
 

--- a/backend/api/tests/views/test_views_computetask.py
+++ b/backend/api/tests/views/test_views_computetask.py
@@ -790,7 +790,7 @@ def test_n_plus_one_queries_compute_task_in_compute_plan(authenticated_client, c
     queries_for_10_tasks = len(queries_10.captured_queries)
 
     assert abs(queries_for_60_tasks - queries_for_10_tasks) < 5
-    assert queries_for_60_tasks < 15
+    assert queries_for_60_tasks < 17
 
 
 @pytest.mark.django_db

--- a/backend/api/tests/views/test_views_computetask.py
+++ b/backend/api/tests/views/test_views_computetask.py
@@ -287,7 +287,7 @@ class GenericTaskViewTests(ComputeTaskViewTests):
                 "authorized_ids": ["MyOrg1MSP"],
             },
             "duration": 0,  # because start_date is None
-            "inputs": [self.datasamples_input, self.opener_input_with_value],
+            "inputs": [self.datasamples_input, self.opener_input],
             "outputs": {"model": self.model_output},
         }
 

--- a/backend/api/tests/views/test_views_performance.py
+++ b/backend/api/tests/views/test_views_performance.py
@@ -356,7 +356,7 @@ def test_n_plus_one_queries_performance_list(authenticated_client, create_comput
         perf_output = t.outputs.all()[1]
         factory.create_performance(perf_output, t.function)
     with utils.CaptureQueriesContext(connection) as query:
-        print(authenticated_client.get(url))
+        authenticated_client.get(url)
     query_task_with_perf = len(query.captured_queries)
     assert query_task_with_perf < 11
     assert query_task_with_perf - query_tasks_empty < 3

--- a/backend/api/views/computetask.py
+++ b/backend/api/views/computetask.py
@@ -188,18 +188,20 @@ class ComputeTaskFilter(FilterSet):
 
 class InputAssetFilter(FilterSet):
     kind = ChoiceInFilter(field_name="asset_kind", choices=FunctionInput.Kind.choices)
+    identifier = CharInFilter(field_name="task_input__identifier")
 
     class Meta:
         model = ComputeTaskInputAsset
-        fields = ["kind"]
+        fields = ["kind", "identifier"]
 
 
 class OutputAssetFilter(FilterSet):
     kind = ChoiceInFilter(field_name="asset_kind", choices=FunctionOutput.Kind.choices)
+    identifier = CharInFilter(field_name="task_output__identifier")
 
     class Meta:
         model = ComputeTaskOutputAsset
-        fields = ["kind"]
+        fields = ["kind", "identifier"]
 
 
 class ComputeTaskViewSetConfig:

--- a/backend/api/views/computetask.py
+++ b/backend/api/views/computetask.py
@@ -291,7 +291,7 @@ class CPTaskViewSet(ComputeTaskViewSetConfig, mixins.ListModelMixin, GenericView
             ComputeTask.objects.filter(channel=get_channel_name(self.request))
             .filter(compute_plan__key=compute_plan_key)
             .select_related("function")
-            .prefetch_related("function__inputs", "function__outputs")
+            .prefetch_related("function__inputs", "function__outputs", "inputs", "outputs")
             .annotate(
                 # Using 0 as default value instead of None for ordering purpose, as default
                 # Postgres behavior considers null as greater than any other value.


### PR DESCRIPTION
## Related issues

- https://github.com/Substra/substra-tests/pull/256
- https://github.com/Substra/substra/pull/361
- https://github.com/Substra/substrafl/pull/129


## Description

:warning: **DO NOT MERGE** until the frontend is switched to the new endpoints.

Following #496, removing deprecated field.
- input: addressable, permissions
- output: values

Fixes FL-568

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203097915891016