### PR TITLE
feat: return {train,test}_data_sample_keys fields in data manager "list" API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add role filter to users list.
 - Endpoints to list task input/output assets
 - "Kind" filters on task input and ouput assets endpoints.
+- Return train_data_sample_keys and test_data_sample_keys fields in data manager "list" API responses
 
 ### Changed
 

--- a/backend/api/tests/views/test_views_datamanager.py
+++ b/backend/api/tests/views/test_views_datamanager.py
@@ -91,6 +91,8 @@ class DataManagerViewTests(APITestCase):
                     "public": False,
                     "authorized_ids": ["MyOrg1MSP"],
                 },
+                "train_data_sample_keys": self.train_data_sample_keys,
+                "test_data_sample_keys": self.test_data_sample_keys,
             },
             {
                 "key": str(data_manager_2.key),
@@ -121,6 +123,8 @@ class DataManagerViewTests(APITestCase):
                     "public": False,
                     "authorized_ids": ["MyOrg1MSP"],
                 },
+                "train_data_sample_keys": [],
+                "test_data_sample_keys": [],
             },
             {
                 "key": str(data_manager_3.key),
@@ -151,6 +155,8 @@ class DataManagerViewTests(APITestCase):
                     "public": False,
                     "authorized_ids": ["MyOrg1MSP"],
                 },
+                "train_data_sample_keys": [],
+                "test_data_sample_keys": [],
             },
         ]
 
@@ -486,8 +492,6 @@ class DataManagerViewTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def test_datamanager_retrieve(self):
-        self.expected_results[0]["train_data_sample_keys"] = self.train_data_sample_keys
-        self.expected_results[0]["test_data_sample_keys"] = self.test_data_sample_keys
         url = reverse("api:data_manager-detail", args=[self.expected_results[0]["key"]])
         response = self.client.get(url, **self.extra)
         self.assertEqual(response.json(), self.expected_results[0])

--- a/backend/api/views/datamanager.py
+++ b/backend/api/views/datamanager.py
@@ -180,7 +180,7 @@ class DataManagerViewSet(mixins.RetrieveModelMixin, mixins.ListModelMixin, mixin
         return DataManager.objects.filter(channel=get_channel_name(self.request))
 
     def get_serializer_class(self):
-        if self.action == "retrieve":
+        if self.action in ["list", "retrieve"]:
             return DataManagerWithRelationsSerializer
         return DataManagerSerializer
 


### PR DESCRIPTION
Without this fix, SDK calls to `client.list_dataset()` returns results missing the `train_data_sample_keys` and `test_data_sample_keys` field. This in turn is interpreted by the SDK as there being no data samples associated with the data manager.

```py
>>> client.list_dataset()
[{
    "key": "f741a383-e9ae-4ceb-9ff5-0803bec98589",
    "name": "XXX",
    "owner": "MyOrg2MSP",
    "permissions": {
        "process": {
            "public": false,
            "authorized_ids": [
                "MyOrg2MSP",
                "MyOrg1MSP"
            ]
        }
    },
    "type": "npy",
    "train_data_sample_keys": [],             # <- even though there are data samples
    "test_data_sample_keys": [],              # <- even though there are data samples
    [...]
}]
```

If accepted, this fix should be backported to release 0.31.x.
