### PR TITLE
refactor: remove task category from compute engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Endpoints to list task input/output assets
 
+### Changed
+
+- Remove task category from the compute engine.
+
 ## [0.32.0] 2022-10-03
 
 ### Changed

--- a/backend/substrapp/compute_tasks/command.py
+++ b/backend/substrapp/compute_tasks/command.py
@@ -40,7 +40,6 @@ def get_exec_command(ctx: Context) -> list[str]:
 def get_exec_command_args(ctx: Context) -> list[str]:
     """Return the substra-tools command line arguments"""
     task = ctx.task
-    task_category = ctx.task.category
 
     in_models_dir = os.path.join(SANDBOX_DIR, TaskDirName.InModels)
     openers_dir = os.path.join(SANDBOX_DIR, TaskDirName.Openers)
@@ -88,11 +87,9 @@ def get_exec_command_args(ctx: Context) -> list[str]:
     for output in ctx.outputs:
         outputs.append(TaskResource(id=output.identifier, value=os.path.join(SANDBOX_DIR, output.rel_path)))
 
-    args = []
-
     rank = str(task.rank)
-    if rank and task_category != orchestrator.ComputeTaskCategory.TASK_PREDICT:
-        args += ["--rank", rank]
+    args = ["--rank", rank]
+
     if ctx.has_chainkeys:
         inputs.append(TaskResource(id=TASK_IO_CHAINKEYS, value=chainkeys_folder))
 

--- a/backend/substrapp/compute_tasks/context.py
+++ b/backend/substrapp/compute_tasks/context.py
@@ -39,7 +39,7 @@ class Context:
     Context represents the execution context of a compute task.
 
     It is scoped to a single compute task. It contains all the context data which is useful during the
-    whole lifetime of a compute task: channel name, task key, category, compute plan key, etc...
+    whole lifetime of a compute task: channel name, task key, compute plan key, etc...
     """
 
     _channel_name: str
@@ -176,3 +176,6 @@ class Context:
             )
 
         return outputs
+
+    def has_output_of_kind(self, kind: orchestrator.AssetKind) -> bool:
+        return any(output.kind == kind for output in self._outputs)

--- a/backend/substrapp/compute_tasks/volumes.py
+++ b/backend/substrapp/compute_tasks/volumes.py
@@ -25,16 +25,15 @@ def get_volumes(ctx: Context):
         ]
     )
 
-    if ctx.task.category == orchestrator.ComputeTaskCategory.TASK_TEST:
-        # testtuple
+    if ctx.has_chainkeys:
+        volume_mounts.append(_create_mount(dirs.task_dir, TaskDirName.Chainkeys))
+
+    if ctx.has_output_of_kind(orchestrator.AssetKind.ASSET_PERFORMANCE):
         volume_mounts.append(_create_mount(dirs.task_dir, TaskDirName.Perf))
-    else:
-        # predicttuple and Xtraintuples
-        volume_mounts.extend(
-            [
-                _create_mount(dirs.task_dir, TaskDirName.Chainkeys),
-                _create_mount(dirs.task_dir, TaskDirName.OutModels),
-            ]
+
+    if ctx.has_output_of_kind(orchestrator.AssetKind.ASSET_MODEL):
+        volume_mounts.append(
+            _create_mount(dirs.task_dir, TaskDirName.OutModels),
         )
 
     volumes = [

--- a/backend/substrapp/tasks/tasks_compute_task.py
+++ b/backend/substrapp/tasks/tasks_compute_task.py
@@ -265,10 +265,9 @@ def _run(
 
             add_assets_to_taskdir(ctx)
 
-            if task.category != orchestrator.ComputeTaskCategory.TASK_TEST:
-                if ctx.has_chainkeys:
-                    _prepare_chainkeys(ctx.directories.compute_plan_dir, ctx.compute_plan.tag)
-                    restore_dir(dirs, CPDirName.Chainkeys, TaskDirName.Chainkeys)
+            if ctx.has_chainkeys:
+                _prepare_chainkeys(ctx.directories.compute_plan_dir, ctx.compute_plan.tag)
+                restore_dir(dirs, CPDirName.Chainkeys, TaskDirName.Chainkeys)
 
             # stop inputs loading timer
             _create_task_profiling_step(channel_name, task.key, ComputeTaskSteps.PREPARE_INPUTS, timer.stop())

--- a/backend/substrapp/tests/compute_tasks/conftest.py
+++ b/backend/substrapp/tests/compute_tasks/conftest.py
@@ -4,7 +4,6 @@ from typing import Any
 import pytest
 
 import orchestrator
-import orchestrator.computetask_pb2 as computetask_pb2
 import orchestrator.mock as orc_mock
 from substrapp.compute_tasks.context import Context
 from substrapp.compute_tasks.directories import Directories
@@ -42,7 +41,6 @@ def testtuple_context(orc_metric) -> Context:
     return Context(
         channel_name="mychannel",
         task={},
-        task_category=computetask_pb2.TASK_TEST,
         task_key=str(uuid.uuid4()),
         compute_plan={},
         compute_plan_key=cp_key,

--- a/backend/substrapp/tests/compute_tasks/test_asset_buffer.py
+++ b/backend/substrapp/tests/compute_tasks/test_asset_buffer.py
@@ -13,7 +13,6 @@ from django.core.files import File
 from django.test import override_settings
 from rest_framework.test import APITestCase
 
-import orchestrator.computetask_pb2 as computetask_pb2
 import orchestrator.mock as orc_mock
 from orchestrator.resources import Address
 from orchestrator.resources import DataManager
@@ -196,7 +195,6 @@ class AssetBufferTests(APITestCase):
             directories = self.dirs
             channel_name = CHANNEL
             compute_plan_key = "some compute plan key"
-            task_category = computetask_pb2.TASK_TRAIN
             metrics = {
                 self.metric_key: {
                     "key": self.metric_key,

--- a/backend/substrapp/tests/compute_tasks/test_command.py
+++ b/backend/substrapp/tests/compute_tasks/test_command.py
@@ -11,13 +11,12 @@ from substrapp.tests.common import InputIdentifiers
 _CHANNEL = "mychannel"
 
 
-def test_get_args_train_task():
+def test_get_args_task_input_one_model_output_one_model():
     model = orc_mock.ModelFactory()
     data_manager = orc_mock.DataManagerFactory()
     ds1 = orc_mock.DataSampleFactory()
     ds2 = orc_mock.DataSampleFactory()
     task = orc_mock.ComputeTaskFactory(
-        category=orchestrator.ComputeTaskCategory.TASK_TRAIN,
         rank=0,
     )
 
@@ -88,14 +87,13 @@ def test_get_args_train_task():
     ]
 
 
-def test_get_args_composite_task():
+def test_get_args_task_input_two_models_output_two_models():
     shared = orc_mock.ModelFactory()
     local = orc_mock.ModelFactory()
     data_manager = orc_mock.DataManagerFactory()
     ds1 = orc_mock.DataSampleFactory()
     ds2 = orc_mock.DataSampleFactory()
     task = orc_mock.ComputeTaskFactory(
-        category=orchestrator.ComputeTaskCategory.TASK_COMPOSITE,
         rank=0,
     )
 
@@ -184,7 +182,6 @@ def test_get_args_predict_after_train():
     ds1 = orc_mock.DataSampleFactory()
     ds2 = orc_mock.DataSampleFactory()
     task = orc_mock.ComputeTaskFactory(
-        category=orchestrator.ComputeTaskCategory.TASK_PREDICT,
         rank=0,
     )
 
@@ -246,6 +243,8 @@ def test_get_args_predict_after_train():
 
     actual = get_exec_command_args(ctx)
     assert actual == [
+        "--rank",
+        "0",
         "--inputs",
         json.dumps(expected_inputs),
         "--outputs",
@@ -253,14 +252,13 @@ def test_get_args_predict_after_train():
     ]
 
 
-def test_get_args_predict_after_composite():
+def test_get_args_predict_input_two_models_output_one_model():
     local = orc_mock.ModelFactory()
     shared = orc_mock.ModelFactory()
     data_manager = orc_mock.DataManagerFactory()
     ds1 = orc_mock.DataSampleFactory()
     ds2 = orc_mock.DataSampleFactory()
     task = orc_mock.ComputeTaskFactory(
-        category=orchestrator.ComputeTaskCategory.TASK_PREDICT,
         rank=0,
     )
 
@@ -327,6 +325,8 @@ def test_get_args_predict_after_composite():
 
     actual = get_exec_command_args(ctx)
     assert actual == [
+        "--rank",
+        "0",
         "--inputs",
         json.dumps(expected_inputs),
         "--outputs",
@@ -334,13 +334,12 @@ def test_get_args_predict_after_composite():
     ]
 
 
-def test_get_args_test_after_predict():
+def test_get_args_test_input_one_model_output_one_performance():
     pred = orc_mock.ModelFactory()
     data_manager = orc_mock.DataManagerFactory()
     ds1 = orc_mock.DataSampleFactory()
     ds2 = orc_mock.DataSampleFactory()
     task = orc_mock.ComputeTaskFactory(
-        category=orchestrator.ComputeTaskCategory.TASK_TEST,
         rank=0,
     )
     algo = orc_mock.AlgoFactory(

--- a/backend/substrapp/tests/tasks/test_compute_task.py
+++ b/backend/substrapp/tests/tasks/test_compute_task.py
@@ -37,7 +37,6 @@ def test_compute_task_exception(mocker: MockerFixture):
         task_dir = tempfile.mkdtemp()
 
     task = orc_mock.ComputeTaskFactory(
-        category=orchestrator.ComputeTaskCategory.TASK_TRAIN,
         status=orchestrator.ComputeTaskStatus.STATUS_DOING,
     )
     # Setup a fake context


### PR DESCRIPTION
## Description

Do not use task category in the compute engine

## How has this been tested?
Local E2E and CI 

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
