### PR TITLE
feat: filter task in/outputs by kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `create` api from model view to submit compute task output.
 - Add role filter to users list.
 - Endpoints to list task input/output assets
+- "Kind" filters on task input and ouput assets endpoints.
 
 ### Changed
 

--- a/backend/api/tests/views/test_views_computetask.py
+++ b/backend/api/tests/views/test_views_computetask.py
@@ -2605,6 +2605,34 @@ class GenericTaskViewTests(ComputeTaskViewTests):
             {"count": len(expected_results), "next": None, "previous": None, "results": expected_results},
         )
 
+    def test_task_list_input_assets_filter(self):
+        url = reverse("api:task-input_assets", args=[self.expected_results[3]["key"]])
+
+        # base response should contain a datamanager and a datasample
+        response = self.client.get(url, **self.extra)
+        data = response.json()
+        assert data["count"] == 2
+
+        # single filter
+        response = self.client.get(url, data={"kind": "ASSET_DATA_MANAGER"}, **self.extra)
+        data = response.json()
+        assert data["count"] == 1
+
+        # multi filter
+        response = self.client.get(url, data={"kind": "ASSET_DATA_MANAGER,ASSET_MODEL"}, **self.extra)
+        data = response.json()
+        assert data["count"] == 1
+
+        # invalid filter
+        response = self.client.get(url, data={"kind": "foo"}, **self.extra)
+        data = response.json()
+        assert data["count"] == 2
+
+        # invalid multi filter
+        response = self.client.get(url, data={"kind": "ASSET_DATA_MANAGER,foo"}, **self.extra)
+        data = response.json()
+        assert data["count"] == 2
+
     def test_task_list_output_assets(self):
         url = reverse("api:task-output_assets", args=[self.expected_results[3]["key"]])
         response = self.client.get(url, **self.extra)
@@ -2619,3 +2647,31 @@ class GenericTaskViewTests(ComputeTaskViewTests):
             response.json(),
             {"count": len(expected_results), "next": None, "previous": None, "results": expected_results},
         )
+
+    def test_task_list_output_assets_filter(self):
+        url = reverse("api:task-output_assets", args=[self.expected_results[3]["key"]])
+
+        # base response should contain a model
+        response = self.client.get(url, **self.extra)
+        data = response.json()
+        assert data["count"] == 1
+
+        # single filter
+        response = self.client.get(url, data={"kind": "ASSET_PERFORMANCE"}, **self.extra)
+        data = response.json()
+        assert data["count"] == 0
+
+        # multi filter
+        response = self.client.get(url, data={"kind": "ASSET_PERFORMANCE,ASSET_MODEL"}, **self.extra)
+        data = response.json()
+        assert data["count"] == 1
+
+        # invalid filter
+        response = self.client.get(url, data={"kind": "foo"}, **self.extra)
+        data = response.json()
+        assert data["count"] == 1
+
+        # invalid multi filter
+        response = self.client.get(url, data={"kind": "ASSET_PERFORMANCE,foo"}, **self.extra)
+        data = response.json()
+        assert data["count"] == 1

--- a/backend/api/views/computetask.py
+++ b/backend/api/views/computetask.py
@@ -23,6 +23,8 @@ from api.models import ComputePlan
 from api.models import ComputeTask
 from api.models import ComputeTaskInputAsset
 from api.models import ComputeTaskOutputAsset
+from api.models.algo import AlgoInput
+from api.models.algo import AlgoOutput
 from api.serializers import ComputeTaskInputAssetSerializer
 from api.serializers import ComputeTaskOutputAssetSerializer
 from api.serializers import ComputeTaskSerializer
@@ -233,6 +235,22 @@ class ComputeTaskFilter(FilterSet):
         }
 
 
+class InputAssetFilter(FilterSet):
+    kind = ChoiceInFilter(field_name="asset_kind", choices=AlgoInput.Kind.choices)
+
+    class Meta:
+        model = ComputeTaskInputAsset
+        fields = ["kind"]
+
+
+class OutputAssetFilter(FilterSet):
+    kind = ChoiceInFilter(field_name="asset_kind", choices=AlgoOutput.Kind.choices)
+
+    class Meta:
+        model = ComputeTaskOutputAsset
+        fields = ["kind"]
+
+
 class ComputeTaskViewSetConfig:
     filter_backends = (ComputePlanKeyOrderingFilter, MatchFilter, DjangoFilterBackend, ComputeTaskMetadataFilter)
     ordering_fields = [
@@ -280,6 +298,7 @@ class ComputeTaskViewSetConfig:
         input_assets = ComputeTaskInputAsset.objects.filter(task_input__task_id=pk).order_by(
             "task_input__identifier", "task_input__position"
         )
+        input_assets = InputAssetFilter(request.GET, queryset=input_assets).qs
 
         context = {"request": request}
         page = self.paginate_queryset(input_assets)
@@ -295,6 +314,7 @@ class ComputeTaskViewSetConfig:
         output_assets = ComputeTaskOutputAsset.objects.filter(task_output__task_id=pk).order_by(
             "task_output__identifier"
         )
+        output_assets = OutputAssetFilter(request.GET, queryset=output_assets).qs
 
         context = {"request": request}
         page = self.paginate_queryset(output_assets)


### PR DESCRIPTION
Signed-off-by: Jérémy Morel <jeremy.morel@owkin.com>

## Description

Adds filtering on the asset_kind property to `/task/<key>/input_assets/` and `/task/<key>/output_assets/`.

It supports multi values with CSV: `/task/<key>/input_assets/?kind=ASSET_DATA_SAMPLE,ASSET_MODEL`.

## How has this been tested?

Through DRF UI and unit tests.

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
