### PR TITLE
ci: only update pip once

### DIFF
--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -58,7 +58,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Update requirements
         run: |
-          python -m pip install --upgrade pip
           pip install --upgrade --upgrade-strategy eager -r backend/dev-requirements.txt
       - name: Test migration
         run: |


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->
The second pip update is not necessary since it's done 2 steps before.

<!-- Please include a summary of your changes. -->

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
