### PR TITLE
fix: Add same expiration date that header_payload to signature cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Compute task outputs/inputs valid storage address.
+- Signature cookie expiration date (#540)
 
 ### Removed
 

--- a/backend/users/views/authentication.py
+++ b/backend/users/views/authentication.py
@@ -64,7 +64,12 @@ class AuthenticationViewSet(GenericViewSet):
             domain=settings.COMMON_HOST_DOMAIN,
         )
         response.set_cookie(
-            "signature", value=signature, expires=access_expires, httponly=True, secure=secure, domain=settings.COMMON_HOST_DOMAIN
+            "signature",
+            value=signature,
+            expires=access_expires,
+            httponly=True,
+            secure=secure,
+            domain=settings.COMMON_HOST_DOMAIN,
         )
         response.set_cookie(
             "refresh",
@@ -111,11 +116,11 @@ class AuthenticationViewSet(GenericViewSet):
             domain=settings.COMMON_HOST_DOMAIN,
         )
         response.set_cookie(
-            "signature", 
-            value=signature, 
-            expires=access_expires, 
-            httponly=True, 
-            secure=secure, 
+            "signature",
+            value=signature,
+            expires=access_expires,
+            httponly=True,
+            secure=secure,
             domain=settings.COMMON_HOST_DOMAIN,
         )
         response.set_cookie(

--- a/backend/users/views/authentication.py
+++ b/backend/users/views/authentication.py
@@ -33,7 +33,6 @@ class AuthenticationViewSet(GenericViewSet):
     @throttle_classes([AnonRateThrottle, UserLoginThrottle])
     def login(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
-
         try:
             serializer.is_valid(raise_exception=True)
         except AuthenticationFailed:
@@ -65,7 +64,7 @@ class AuthenticationViewSet(GenericViewSet):
             domain=settings.COMMON_HOST_DOMAIN,
         )
         response.set_cookie(
-            "signature", value=signature, httponly=True, secure=secure, domain=settings.COMMON_HOST_DOMAIN
+            "signature", value=signature, expires=access_expires, httponly=True, secure=secure, domain=settings.COMMON_HOST_DOMAIN
         )
         response.set_cookie(
             "refresh",
@@ -81,7 +80,6 @@ class AuthenticationViewSet(GenericViewSet):
     @action(methods=["post"], detail=False)
     def refresh(self, request, *args, **kwargs):
         serializer = CustomTokenRefreshSerializer(data=request.data, context=self.get_serializer_context())
-
         try:
             serializer.is_valid(raise_exception=True)
         except AuthenticationFailed:

--- a/backend/users/views/authentication.py
+++ b/backend/users/views/authentication.py
@@ -111,7 +111,12 @@ class AuthenticationViewSet(GenericViewSet):
             domain=settings.COMMON_HOST_DOMAIN,
         )
         response.set_cookie(
-            "signature", value=signature, httponly=True, secure=secure, domain=settings.COMMON_HOST_DOMAIN
+            "signature", 
+            value=signature, 
+            expires=access_expires, 
+            httponly=True, 
+            secure=secure, 
+            domain=settings.COMMON_HOST_DOMAIN,
         )
         response.set_cookie(
             "refresh",


### PR DESCRIPTION
## Description

Access token in Substra is secured by separating the cookie in 2 cookies: header_payload and signature. The header_payload cookie has a 24h expiration date but the signature had none. Because of this once the header_payload expired there was a bug as the signature was still existing which blocked the creation of a new pair of cookies (be it from the refresh token or entering credentials again), which led to the user having to delete the signature cookie manually to resolve the issue.
This fix only give the same expiration date to the signature cookie so that it disappears at the same time as header_payload. If the user still has a refresh token (1 week expiration date), a new header_payload-signature pair will be fetched automatically, otherwise credentials have to be entered anew.

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
