### PR TITLE
chore(github): update code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
-* @AlexandrePicosson @AurelienGasser @cboillet-dev @Kelvin-M @mblottiere @samlesu @sergebouchut2 @ThibaultFy @oleobal @Milouu @guilhem-barthes
+# historic code owners
+* @AlexandrePicosson @cboillet-dev @Kelvin-M @mblottiere @samlesu @sergebouchut2
+# Owkin FL squad
+* @ThibaultFy @oleobal @Milouu @guilhem-barthes


### PR DESCRIPTION
## Description

Remove Aurélien Gasser

Also split it in two lines like the orchestrator. Maybe we could remove the veterans to stop showering them in notifications?
