### PR TITLE
fix(skaffold): create secrets before deploying releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Contributing, contributors & code of conduct files (#563)
 
+### Fixed
+- Skaffold default example configuration (([#570](https://github.com/Substra/substra-backend/pull/570)))
+
 ### Removed
 
 - Test only field for data samples (#551)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contributing, contributors & code of conduct files (#563)
 
 ### Fixed
-- Skaffold default example configuration (([#570](https://github.com/Substra/substra-backend/pull/570)))
+- Skaffold default example configuration ([#570](https://github.com/Substra/substra-backend/pull/570))
 
 ### Removed
 

--- a/examples/secrets/skaffold.yaml
+++ b/examples/secrets/skaffold.yaml
@@ -1,0 +1,9 @@
+apiVersion: skaffold/v2beta11
+kind: Config
+metadata:
+  name: setup-secrets
+deploy:
+  kubectl:
+    manifests:
+        - ./secret-orchestrator-tls-org-1-client-pair.yaml
+        - ./secret-orchestrator-tls-org-2-client-pair.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,7 +1,6 @@
 apiVersion: skaffold/v2beta24
 kind: Config
 
-# Remove if you desactivate mTLS
 requires:
   - path: examples/secrets/skaffold.yaml
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,5 +1,10 @@
 apiVersion: skaffold/v2beta24
 kind: Config
+
+# Remove if you desactivate mTLS
+requires:
+  - path: examples/secrets/skaffold.yaml
+
 build:
   artifacts:
     - image: substra/substra-backend
@@ -54,8 +59,6 @@ deploy:
     manifests:
       - examples/values/serviceAccounts/serviceAccount-org-1.yaml
       - examples/values/serviceAccounts/serviceAccount-org-2.yaml
-      - examples/secrets/secret-orchestrator-tls-org-1-client-pair.yaml
-      - examples/secrets/secret-orchestrator-tls-org-2-client-pair.yaml
 
 profiles:
   - name: prod


### PR DESCRIPTION
Signed-off-by: Guilhem Barthes <guilhem.barthes@owkin.com>

## Description

This move the secrets creation in another module so it can be run before deploying on Helm.

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
