### PR TITLE
fix(skaffold): Skaffold spawns too many backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contributing, contributors & code of conduct files (#563)
 
 ### Fixed
+
 - Skaffold default example configuration ([#570](https://github.com/Substra/substra-backend/pull/570))
+- Skaffold spawning instances in `default` namespace ([#574](https://github.com/Substra/substra-backend/pull/574))
 
 ### Removed
 

--- a/examples/secrets/skaffold.yaml
+++ b/examples/secrets/skaffold.yaml
@@ -5,5 +5,5 @@ metadata:
 deploy:
   kubectl:
     manifests:
-        - ./secret-orchestrator-tls-org-1-client-pair.yaml
-        - ./secret-orchestrator-tls-org-2-client-pair.yaml
+    - ./secret-orchestrator-tls-org-1-client-pair.yaml
+    - ./secret-orchestrator-tls-org-2-client-pair.yaml

--- a/examples/values/serviceAccounts/skaffold.yaml
+++ b/examples/values/serviceAccounts/skaffold.yaml
@@ -1,0 +1,9 @@
+apiVersion: skaffold/v2beta11
+kind: Config
+metadata:
+  name: setup-service-accounts
+deploy:
+  kubectl:
+    manifests:
+    - ./serviceAccount-org-1.yaml
+    - ./serviceAccount-org-2.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -17,21 +17,6 @@ build:
       docker:
         dockerfile: docker/substra-backend/Dockerfile
 
-
-manifests:
-  hooks:
-    before:
-      - host:
-          # `skaffold run` does not update chart dependencies:
-          # https://github.com/GoogleContainerTools/skaffold/issues/5445
-          # So we update the dependencies ourselves.
-          command:
-          - 'helm'
-          - 'dep'
-          - 'build'
-          - 'charts/substra-backend'
-          os: [darwin, linux]
-
 deploy:
   helm:
     releases:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -56,8 +56,6 @@ deploy:
           _: _
         setValueTemplates: *image-tags
         createNamespace: true
-         valuesFiles: [ examples/values/backend-org-2.yaml ]
-        setValues: { _: _ } # to support profiles
         skipBuildDependencies: true
     statusCheckDeadlineSeconds: 660
   

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -17,7 +17,7 @@ build:
       docker:
         dockerfile: docker/substra-backend/Dockerfile
 
-deploy:
+manifests:
   helm:
     releases:
       - name: backend-org-1
@@ -38,6 +38,8 @@ deploy:
           worker.events.image: *image-params
           worker.image: *image-params
         createNamespace: true
+        skipBuildDependencies: true
+        
       - name: backend-org-2
         chartPath: charts/substra-backend
         valuesFiles:
@@ -48,6 +50,18 @@ deploy:
         setValueTemplates: *image-tags
         createNamespace: true
         skipBuildDependencies: true
+  hooks:
+    before:
+      - host:
+        # `skaffold run` does not update chart dependencies:
+        # https://github.com/GoogleContainerTools/skaffold/issues/5445
+        # So we update the dependencies ourselves.
+        command:
+        - 'helm'
+        - 'dep'
+        - 'build'
+        - 'charts/substra-backend'
+        os: [darwin, linux]
   statusCheckDeadlineSeconds: 660
   
 
@@ -67,11 +81,6 @@ profiles:
       - op: add
         path: /build/artifacts/0/docker/target
         value: dev  # install dev-requirements
-  - name: nodeps
-    patches:
-      - op: add
-        path: /deploy/helm/releases/0/skipBuildDependencies
-        value: true
   - name: arm64
     patches:
       - op: add

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -38,7 +38,6 @@ deploy:
           worker.events.image: *image-params
           worker.image: *image-params
         createNamespace: true
-        skipBuildDependencies: true
         
       - name: backend-org-2
         chartPath: charts/substra-backend
@@ -64,6 +63,11 @@ profiles:
       - op: add
         path: /deploy/helm/releases/1/setValues/settings
         value: prod
+   - name: nodeps
+    patches:
+      - op: add
+        path: /deploy/helm/releases/0/skipBuildDependencies
+        value: true
   - name: dev
     patches:
       - op: add

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v2beta24
+apiVersion: skaffold/v4beta2
 kind: Config
 
 requires:
@@ -9,52 +9,57 @@ build:
   artifacts:
     - image: substra/substra-backend
       context: .
-      docker:
-        dockerfile: docker/substra-backend/Dockerfile
       sync:
         manual:
         - src: backend/**/*
           dest: /usr/src/app
           strip: backend/
+      docker:
+        dockerfile: docker/substra-backend/Dockerfile
 
 deploy:
-  statusCheckDeadlineSeconds: 600
   helm:
     releases:
       - name: backend-org-1
         chartPath: charts/substra-backend
+        valuesFiles:
+        - examples/values/backend-org-1.yaml
         namespace: org-1
+        setValues:
+          _: _
+        setValueTemplates: &image-tags
+          api.events.image.registry: &image-registry '{{.IMAGE_DOMAIN_substra_substra_backend}}'
+          api.events.image.repository: &image-repository '{{.IMAGE_REPO_NO_DOMAIN_substra_substra_backend}}'
+          api.events.image.tag: &image-tag '{{.IMAGE_TAG_substra_substra_backend}}'
+          scheduler.image.registry: *image-registry
+          scheduler.image.repository: *image-repository
+          scheduler.image.tag: *image-tag
+          schedulerWorker.image.registry: *image-registry
+          schedulerWorker.image.repository: *image-repository
+          schedulerWorker.image.tag: *image-tag
+          server.image.registry: *image-registry
+          server.image.repository: *image-repository
+          server.image.tag: *image-tag
+          worker.events.image.registry: *image-registry
+          worker.events.image.repository: *image-repository
+          worker.events.image.tag: *image-tag
+          worker.image.registry: *image-registry
+          worker.image.repository: *image-repository
+          worker.image.tag: *image-tag
         createNamespace: true
-        valuesFiles: [ examples/values/backend-org-1.yaml ]
-        setValues: { _: _ } # to support profiles
-        imageStrategy:
-          helm:
-            explicitRegistry: true
-        artifactOverrides:
-          server.image: substra/substra-backend
-          scheduler.image: substra/substra-backend
-          worker.image: substra/substra-backend
-          schedulerWorker.image: substra/substra-backend
-          worker.events.image: substra/substra-backend
-          api.events.image: substra/substra-backend
-
       - name: backend-org-2
         chartPath: charts/substra-backend
+        valuesFiles:
+        - examples/values/backend-org-2.yaml
         namespace: org-2
+        setValues:
+          _: _
+        setValueTemplates: *image-tags
         createNamespace: true
-        valuesFiles: [ examples/values/backend-org-2.yaml ]
+         valuesFiles: [ examples/values/backend-org-2.yaml ]
         setValues: { _: _ } # to support profiles
-        imageStrategy:
-          helm:
-            explicitRegistry: true
-        artifactOverrides:
-          server.image: substra/substra-backend
-          scheduler.image: substra/substra-backend
-          worker.image: substra/substra-backend
-          schedulerWorker.image: substra/substra-backend
-          worker.events.image: substra/substra-backend
-          api.events.image: substra/substra-backend
         skipBuildDependencies: true
+    statusCheckDeadlineSeconds: 660
   
 
   

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -175,7 +175,7 @@ profiles:
           docker:
             dockerfile: docker/metrics-exporter/Dockerfile
       - op: add
-        path: /deploy/helm/releases/0/artifactOverrides/server.metrics.image
+        path: /deploy/helm/releases/0/setValues/server.metrics.image
         value: substra/metrics-exporter
       - op: add
         path: /deploy/helm/releases/0/setValues/server.metrics.enabled

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -17,7 +17,22 @@ build:
       docker:
         dockerfile: docker/substra-backend/Dockerfile
 
+
 manifests:
+  hooks:
+    before:
+      - host:
+          # `skaffold run` does not update chart dependencies:
+          # https://github.com/GoogleContainerTools/skaffold/issues/5445
+          # So we update the dependencies ourselves.
+          command:
+          - 'helm'
+          - 'dep'
+          - 'build'
+          - 'charts/substra-backend'
+          os: [darwin, linux]
+
+deploy:
   helm:
     releases:
       - name: backend-org-1
@@ -28,7 +43,7 @@ manifests:
         setValues:
           _: _
         setValueTemplates: &image-tags
-          api.events.image: &image-params
+          api.events.image: &image-params 
             registry: '{{.IMAGE_DOMAIN_substra_substra_backend}}'
             repository: '{{.IMAGE_REPO_NO_DOMAIN_substra_substra_backend}}'
             tag: '{{.IMAGE_TAG_substra_substra_backend}}'
@@ -50,18 +65,6 @@ manifests:
         setValueTemplates: *image-tags
         createNamespace: true
         skipBuildDependencies: true
-  hooks:
-    before:
-      - host:
-          # `skaffold run` does not update chart dependencies:
-          # https://github.com/GoogleContainerTools/skaffold/issues/5445
-          # So we update the dependencies ourselves.
-          command:
-          - 'helm'
-          - 'dep'
-          - 'build'
-          - 'charts/substra-backend'
-          os: [darwin, linux]
   statusCheckDeadlineSeconds: 660
   
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -28,24 +28,15 @@ deploy:
         setValues:
           _: _
         setValueTemplates: &image-tags
-          api.events.image.registry: &image-registry '{{.IMAGE_DOMAIN_substra_substra_backend}}'
-          api.events.image.repository: &image-repository '{{.IMAGE_REPO_NO_DOMAIN_substra_substra_backend}}'
-          api.events.image.tag: &image-tag '{{.IMAGE_TAG_substra_substra_backend}}'
-          scheduler.image.registry: *image-registry
-          scheduler.image.repository: *image-repository
-          scheduler.image.tag: *image-tag
-          schedulerWorker.image.registry: *image-registry
-          schedulerWorker.image.repository: *image-repository
-          schedulerWorker.image.tag: *image-tag
-          server.image.registry: *image-registry
-          server.image.repository: *image-repository
-          server.image.tag: *image-tag
-          worker.events.image.registry: *image-registry
-          worker.events.image.repository: *image-repository
-          worker.events.image.tag: *image-tag
-          worker.image.registry: *image-registry
-          worker.image.repository: *image-repository
-          worker.image.tag: *image-tag
+          api.events.image: &image-params
+            registry: '{{.IMAGE_DOMAIN_substra_substra_backend}}'
+            repository: '{{.IMAGE_REPO_NO_DOMAIN_substra_substra_backend}}'
+            tag: '{{.IMAGE_TAG_substra_substra_backend}}'
+          scheduler.image: *image-params
+          schedulerWorker.image: *image-params
+          server.image: *image-params
+          worker.events.image: *image-params
+          worker.image: *image-params
         createNamespace: true
       - name: backend-org-2
         chartPath: charts/substra-backend
@@ -57,7 +48,7 @@ deploy:
         setValueTemplates: *image-tags
         createNamespace: true
         skipBuildDependencies: true
-    statusCheckDeadlineSeconds: 660
+  statusCheckDeadlineSeconds: 660
   
 
   

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -53,15 +53,15 @@ manifests:
   hooks:
     before:
       - host:
-        # `skaffold run` does not update chart dependencies:
-        # https://github.com/GoogleContainerTools/skaffold/issues/5445
-        # So we update the dependencies ourselves.
-        command:
-        - 'helm'
-        - 'dep'
-        - 'build'
-        - 'charts/substra-backend'
-        os: [darwin, linux]
+          # `skaffold run` does not update chart dependencies:
+          # https://github.com/GoogleContainerTools/skaffold/issues/5445
+          # So we update the dependencies ourselves.
+          command:
+          - 'helm'
+          - 'dep'
+          - 'build'
+          - 'charts/substra-backend'
+          os: [darwin, linux]
   statusCheckDeadlineSeconds: 660
   
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -3,6 +3,7 @@ kind: Config
 
 requires:
   - path: examples/secrets/skaffold.yaml
+  - path: examples/values/serviceAccounts/skaffold.yaml
 
 build:
   artifacts:
@@ -53,11 +54,10 @@ deploy:
           schedulerWorker.image: substra/substra-backend
           worker.events.image: substra/substra-backend
           api.events.image: substra/substra-backend
-        skipBuildDependencies: true # deps already built by other org-1 release
-  kubectl:
-    manifests:
-      - examples/values/serviceAccounts/serviceAccount-org-1.yaml
-      - examples/values/serviceAccounts/serviceAccount-org-2.yaml
+        skipBuildDependencies: true
+  
+
+  
 
 profiles:
   - name: prod


### PR DESCRIPTION
## Companion PR

- https://github.com/Substra/hlf-k8s/pull/147
- https://github.com/Substra/orchestrator/pull/144

## Description

Update skaffold schema to `v4beta2` due to migration to Skaffold version `2.x.x` which was compatible with our schemas.


## Description

Update skaffold schema to `v4beta2` due to migration to Skaffold version `2.x.x` which was compatible with our schemas and leverages new `setValueTemplate` instead of `artifactOverrides`.

## How has this been tested?

Local tests & CI

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
