### PR TITLE
chore: Add new filters for performances export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]()
 
+### Added
+
+- Add filters to performances export (#590)
+
 ### Changed
 
 - BREAKING: rename Algo to Function ([#573](https://github.com/Substra/substra-backend/pull/573))

--- a/backend/api/tests/views/test_views_performance.py
+++ b/backend/api/tests/views/test_views_performance.py
@@ -315,7 +315,7 @@ class PerformanceViewTests(APITestCase):
 
     def test_performance_export_with_metadata(self):
         metadata = "epochs,hidden_sizes,last_hidden_sizes"
-        params = urlencode({"metadata": metadata})
+        params = urlencode({"metadata_columns": metadata})
         response = self.client.get(f"{self.export_url}?{params}", **self.export_extra)
         content_list = list(response.streaming_content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/backend/api/views/performance.py
+++ b/backend/api/views/performance.py
@@ -99,8 +99,8 @@ def _build_csv_headers(request) -> list:
         "compute_plan_start_date",
         "compute_plan_end_date",
     ]
-    if request.query_params.get("metadata"):
-        for md in request.query_params.get("metadata").split(","):
+    if request.query_params.get("metadata_columns"):
+        for md in request.query_params.get("metadata_columns").split(","):
             headers.append(md)
     headers.extend(["function_name", "worker", "task_rank", "task_round", "performance"])
     return headers
@@ -127,8 +127,8 @@ class PerformanceViewSet(mixins.ListModelMixin, GenericViewSet):
 
     def get_queryset(self):
         metadata = {}
-        if self.request.query_params.get("metadata"):
-            for md in self.request.query_params.get("metadata").split(","):
+        if self.request.query_params.get("metadata_columns"):
+            for md in self.request.query_params.get("metadata_columns").split(","):
                 metadata[md] = F("compute_task__compute_plan__metadata__" + md)
 
         return (

--- a/backend/api/views/performance.py
+++ b/backend/api/views/performance.py
@@ -82,6 +82,8 @@ class PerformanceFilter(FilterSet):
     )
     key = UUIDInFilter(field_name="compute_task__compute_plan__key")
     owner = CharInFilter(field_name="compute_task__compute_plan__owner")
+    metric_key = UUIDInFilter(field_name="metric__key")
+    metric_output_identifier = CharInFilter(field_name="metric__outputs__identifier")
 
 
 class PerformanceMatchFilter(MatchFilter):
@@ -131,7 +133,7 @@ class PerformanceViewSet(mixins.ListModelMixin, GenericViewSet):
 
         return (
             Performance.objects.filter(channel=get_channel_name(self.request))
-            .select_related("compute_task", "metric", "compute_task__compute_plan")
+            .select_related("compute_task", "metric", "compute_task__compute_plan", "metric__outputs")
             .annotate(
                 compute_plan_key=F("compute_task__compute_plan__key"),
                 compute_plan_name=F("compute_task__compute_plan__name"),

--- a/backend/api/views/performance.py
+++ b/backend/api/views/performance.py
@@ -18,6 +18,7 @@ from api.models import ComputePlan as ComputePlan
 from api.models import Performance as Performance
 from api.serializers import CPPerformanceSerializer as CPPerformanceSerializer
 from api.serializers import ExportPerformanceSerializer as ExportPerformanceSerializer
+from api.views.computeplan import ComputePlanMetadataFilter
 from api.views.filters_utils import CharInFilter
 from api.views.filters_utils import ChoiceInFilter
 from api.views.filters_utils import MatchFilter
@@ -119,7 +120,7 @@ def map_compute_plan_status(value) -> str:
 
 class PerformanceViewSet(mixins.ListModelMixin, GenericViewSet):
     serializer_class = ExportPerformanceSerializer
-    filter_backends = [PerformanceMatchFilter, OrderingFilter, DjangoFilterBackend]
+    filter_backends = [PerformanceMatchFilter, OrderingFilter, DjangoFilterBackend, ComputePlanMetadataFilter]
     ordering_fields = ["task_rank", "task_round", "worker"]
     ordering = ["task_rank", "task_round", "worker"]
     pagination_class = LargePageNumberPagination


### PR DESCRIPTION
Signed-off-by: Milouu <milan.roustan@owkin.com>

## Description

Add new filters for filtering performances export by metric_key and metric_output_identifier. This is needed in the frontend to be able to download only the performances of a single performance chart.

Companion PR: https://github.com/Substra/substra-frontend/pull/156
