### PR TITLE
chore(helm): default image tag to AppVersion

### DIFF
--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 22.3.4
+
+### Changed
+- Make backend image tags default to the chart `appVersion`, and set it to `null` in the default values
+
 ## 22.3.3
 
 ### Changed

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: substra-backend
 home: https://github.com/Substra
-version: 22.3.3
+version: 22.3.4
 appVersion: 0.35.1
 kubeVersion: ">= 1.19.0-0"
 description: Main package for Substra

--- a/charts/substra-backend/README.md
+++ b/charts/substra-backend/README.md
@@ -48,7 +48,7 @@ See [UPGRADE.md](https://github.com/Substra/substra-backend/blob/main/charts/sub
 | `server.uwsgiThreads`                             | The number of uwsgi threads                                                                                                                        | `10`                                       |
 | `server.image.registry`                           | Substra backend server image registry                                                                                                              | `ghcr.io`                                  |
 | `server.image.repository`                         | Substra backend server image repository                                                                                                            | `substra/substra-backend`                  |
-| `server.image.tag`                                | Substra backend server image tag                                                                                                                   | `0.35.1`                                   |
+| `server.image.tag`                                | Substra backend server image tag (defaults to AppVersion)                                                                                          | `nil`                                      |
 | `server.image.pullPolicy`                         | Substra backend server image pull policy                                                                                                           | `IfNotPresent`                             |
 | `server.image.pullSecrets`                        | Specify image pull secrets                                                                                                                         | `[]`                                       |
 | `server.podSecurityContext.enabled`               | Enable security context                                                                                                                            | `true`                                     |
@@ -93,7 +93,7 @@ See [UPGRADE.md](https://github.com/Substra/substra-backend/blob/main/charts/sub
 | `server.metrics.enabled`                          | Start a prometheus exporter                                                                                                                        | `false`                                    |
 | `server.metrics.image.registry`                   | Substra backend server Prometheus Exporter image registry                                                                                          | `ghcr.io`                                  |
 | `server.metrics.image.repository`                 | Substra backend server Prometheus Exporter image repository                                                                                        | `substra/substra-backend-metrics-exporter` |
-| `server.metrics.image.tag`                        | Substra backend server Prometheus Exporter image tag                                                                                               | `0.35.1`                                   |
+| `server.metrics.image.tag`                        | Substra backend server Prometheus Exporter image tag (defaults to AppVersion)                                                                      | `nil`                                      |
 | `server.metrics.image.pullPolicy`                 | Substra backend server Prometheus Exporter image pull policy                                                                                       | `IfNotPresent`                             |
 | `server.metrics.serviceMonitor.enabled`           | Create ServiceMonitor resource for scraping metrics using Prometheus Operator                                                                      | `false`                                    |
 | `server.metrics.serviceMonitor.namespace`         | Namespace for the ServiceMonitor resource (defaults to the Release Namespace)                                                                      | `""`                                       |
@@ -113,7 +113,7 @@ See [UPGRADE.md](https://github.com/Substra/substra-backend/blob/main/charts/sub
 | `worker.concurrency`                           | Maximum amount of tasks to process in parallel                                                                                                     | `1`                       |
 | `worker.image.registry`                        | Substra backend worker image registry                                                                                                              | `ghcr.io`                 |
 | `worker.image.repository`                      | Substra backend worker image repository                                                                                                            | `substra/substra-backend` |
-| `worker.image.tag`                             | Substra backend worker image tag                                                                                                                   | `0.35.1`                  |
+| `worker.image.tag`                             | Substra backend worker image tag (defaults to AppVersion)                                                                                          | `nil`                     |
 | `worker.image.pullPolicy`                      | Substra backend worker image pull policy                                                                                                           | `IfNotPresent`            |
 | `worker.image.pullSecrets`                     | Specify image pull secrets                                                                                                                         | `[]`                      |
 | `worker.podSecurityContext.enabled`            | Enable security context                                                                                                                            | `true`                    |
@@ -134,7 +134,7 @@ See [UPGRADE.md](https://github.com/Substra/substra-backend/blob/main/charts/sub
 | `worker.events.enabled`                        | Enable event service                                                                                                                               | `true`                    |
 | `worker.events.image.registry`                 | Substra event app image registry                                                                                                                   | `ghcr.io`                 |
 | `worker.events.image.repository`               | Substra event app image repository                                                                                                                 | `substra/substra-backend` |
-| `worker.events.image.tag`                      | Substra event app image tag                                                                                                                        | `0.35.1`                  |
+| `worker.events.image.tag`                      | Substra event app image tag (defaults to AppVersion)                                                                                               | `nil`                     |
 | `worker.events.image.pullPolicy`               | Substra event app image pull policy                                                                                                                | `IfNotPresent`            |
 | `worker.events.image.pullSecrets`              | Specify image pull secrets                                                                                                                         | `[]`                      |
 | `worker.events.podSecurityContext.enabled`     | Enable security context                                                                                                                            | `true`                    |
@@ -151,44 +151,44 @@ See [UPGRADE.md](https://github.com/Substra/substra-backend/blob/main/charts/sub
 
 ### Substra periodic tasks worker settings
 
-| Name                                            | Description                                       | Value                     |
-| ----------------------------------------------- | ------------------------------------------------- | ------------------------- |
-| `schedulerWorker.enabled`                       | Enable scheduler worker service                   | `true`                    |
-| `schedulerWorker.replicaCount`                  | Replica count for the periodic tasks worker       | `1`                       |
-| `schedulerWorker.image.registry`                | Substra backend tasks scheduler image registry    | `ghcr.io`                 |
-| `schedulerWorker.image.repository`              | Substra backend tasks scheduler image repository  | `substra/substra-backend` |
-| `schedulerWorker.image.tag`                     | Substra backend tasks scheduler image tag         | `0.35.1`                  |
-| `schedulerWorker.image.pullPolicy`              | Substra backend task scheduler image pull policy  | `IfNotPresent`            |
-| `schedulerWorker.image.pullSecrets`             | Specify image pull secrets                        | `[]`                      |
-| `schedulerWorker.nodeSelector`                  | Node labels for pod assignment                    | `{}`                      |
-| `schedulerWorker.tolerations`                   | Toleration labels for pod assignment              | `[]`                      |
-| `schedulerWorker.affinity`                      | Affinity settings for pod assignment              | `{}`                      |
-| `schedulerWorker.resources`                     | Scheduler container resources requests and limits | `{}`                      |
-| `schedulerWorker.podSecurityContext.enabled`    | Enable security context                           | `true`                    |
-| `schedulerWorker.podSecurityContext.runAsUser`  | User ID for the pod                               | `1001`                    |
-| `schedulerWorker.podSecurityContext.runAsGroup` | Group ID for the pod                              | `1001`                    |
-| `schedulerWorker.podSecurityContext.fsGroup`    | FileSystem group ID for the pod                   | `1001`                    |
+| Name                                            | Description                                                        | Value                     |
+| ----------------------------------------------- | ------------------------------------------------------------------ | ------------------------- |
+| `schedulerWorker.enabled`                       | Enable scheduler worker service                                    | `true`                    |
+| `schedulerWorker.replicaCount`                  | Replica count for the periodic tasks worker                        | `1`                       |
+| `schedulerWorker.image.registry`                | Substra backend tasks scheduler image registry                     | `ghcr.io`                 |
+| `schedulerWorker.image.repository`              | Substra backend tasks scheduler image repository                   | `substra/substra-backend` |
+| `schedulerWorker.image.tag`                     | Substra backend tasks scheduler image tag (defaults to AppVersion) | `nil`                     |
+| `schedulerWorker.image.pullPolicy`              | Substra backend task scheduler image pull policy                   | `IfNotPresent`            |
+| `schedulerWorker.image.pullSecrets`             | Specify image pull secrets                                         | `[]`                      |
+| `schedulerWorker.nodeSelector`                  | Node labels for pod assignment                                     | `{}`                      |
+| `schedulerWorker.tolerations`                   | Toleration labels for pod assignment                               | `[]`                      |
+| `schedulerWorker.affinity`                      | Affinity settings for pod assignment                               | `{}`                      |
+| `schedulerWorker.resources`                     | Scheduler container resources requests and limits                  | `{}`                      |
+| `schedulerWorker.podSecurityContext.enabled`    | Enable security context                                            | `true`                    |
+| `schedulerWorker.podSecurityContext.runAsUser`  | User ID for the pod                                                | `1001`                    |
+| `schedulerWorker.podSecurityContext.runAsGroup` | Group ID for the pod                                               | `1001`                    |
+| `schedulerWorker.podSecurityContext.fsGroup`    | FileSystem group ID for the pod                                    | `1001`                    |
 
 
 ### Celery task scheduler settings
 
-| Name                                      | Description                                       | Value                     |
-| ----------------------------------------- | ------------------------------------------------- | ------------------------- |
-| `scheduler.enabled`                       | Enable scheduler service                          | `true`                    |
-| `scheduler.replicaCount`                  | Replica count for the scheduler server            | `1`                       |
-| `scheduler.image.registry`                | Subsra backend tasks scheduler image registry     | `ghcr.io`                 |
-| `scheduler.image.repository`              | Substra backend tasks scheduler image repository  | `substra/substra-backend` |
-| `scheduler.image.tag`                     | Substra backend tasks scheduler image tag         | `0.35.1`                  |
-| `scheduler.image.pullPolicy`              | Substra backend task scheduler image pull policy  | `IfNotPresent`            |
-| `scheduler.image.pullSecrets`             | Specify image pull secrets                        | `[]`                      |
-| `scheduler.resources`                     | Scheduler container resources requests and limits | `{}`                      |
-| `scheduler.nodeSelector`                  | Node labels for pod assignment                    | `{}`                      |
-| `scheduler.tolerations`                   | Toleration labels for pod assignment              | `[]`                      |
-| `scheduler.affinity`                      | Affinity settings for pod assignment              | `{}`                      |
-| `scheduler.podSecurityContext.enabled`    | Enable security context                           | `true`                    |
-| `scheduler.podSecurityContext.runAsUser`  | User ID for the pod                               | `1001`                    |
-| `scheduler.podSecurityContext.runAsGroup` | Group ID for the pod                              | `1001`                    |
-| `scheduler.podSecurityContext.fsGroup`    | FileSystem group ID for the pod                   | `1001`                    |
+| Name                                      | Description                                                        | Value                     |
+| ----------------------------------------- | ------------------------------------------------------------------ | ------------------------- |
+| `scheduler.enabled`                       | Enable scheduler service                                           | `true`                    |
+| `scheduler.replicaCount`                  | Replica count for the scheduler server                             | `1`                       |
+| `scheduler.image.registry`                | Subsra backend tasks scheduler image registry                      | `ghcr.io`                 |
+| `scheduler.image.repository`              | Substra backend tasks scheduler image repository                   | `substra/substra-backend` |
+| `scheduler.image.tag`                     | Substra backend tasks scheduler image tag (defaults to AppVersion) | `nil`                     |
+| `scheduler.image.pullPolicy`              | Substra backend task scheduler image pull policy                   | `IfNotPresent`            |
+| `scheduler.image.pullSecrets`             | Specify image pull secrets                                         | `[]`                      |
+| `scheduler.resources`                     | Scheduler container resources requests and limits                  | `{}`                      |
+| `scheduler.nodeSelector`                  | Node labels for pod assignment                                     | `{}`                      |
+| `scheduler.tolerations`                   | Toleration labels for pod assignment                               | `[]`                      |
+| `scheduler.affinity`                      | Affinity settings for pod assignment                               | `{}`                      |
+| `scheduler.podSecurityContext.enabled`    | Enable security context                                            | `true`                    |
+| `scheduler.podSecurityContext.runAsUser`  | User ID for the pod                                                | `1001`                    |
+| `scheduler.podSecurityContext.runAsGroup` | Group ID for the pod                                               | `1001`                    |
+| `scheduler.podSecurityContext.fsGroup`    | FileSystem group ID for the pod                                    | `1001`                    |
 
 
 ### Substra container registry settings
@@ -205,24 +205,24 @@ See [UPGRADE.md](https://github.com/Substra/substra-backend/blob/main/charts/sub
 
 ### Api event app settings
 
-| Name                                       | Description                                         | Value                     |
-| ------------------------------------------ | --------------------------------------------------- | ------------------------- |
-| `api.events.enabled`                       | Enable event service                                | `true`                    |
-| `api.events.image.registry`                | Substra event app image registry                    | `ghcr.io`                 |
-| `api.events.image.repository`              | Substra event app image repository                  | `substra/substra-backend` |
-| `api.events.image.tag`                     | Substra event app image tag                         | `0.35.1`                  |
-| `api.events.image.pullPolicy`              | Substra event app image pull policy                 | `IfNotPresent`            |
-| `api.events.image.pullSecrets`             | Specify image pull secrets                          | `[]`                      |
-| `api.events.podSecurityContext.enabled`    | Enable security context                             | `true`                    |
-| `api.events.podSecurityContext.runAsUser`  | User ID for the pod                                 | `1001`                    |
-| `api.events.podSecurityContext.runAsGroup` | Group ID for the pod                                | `1001`                    |
-| `api.events.podSecurityContext.fsGroup`    | FileSystem group ID for the pod                     | `1001`                    |
-| `api.events.nodeSelector`                  | Node labels for pod assignment                      | `{}`                      |
-| `api.events.tolerations`                   | Toleration labels for pod assignment                | `[]`                      |
-| `api.events.affinity`                      | Affinity settings for pod assignment                | `{}`                      |
-| `api.events.rbac.create`                   | Create a role and service account for the event app | `true`                    |
-| `api.events.serviceAccount.create`         | Create a service account for the event app          | `true`                    |
-| `api.events.serviceAccount.name`           | The name of the ServiceAccount to use               | `""`                      |
+| Name                                       | Description                                          | Value                     |
+| ------------------------------------------ | ---------------------------------------------------- | ------------------------- |
+| `api.events.enabled`                       | Enable event service                                 | `true`                    |
+| `api.events.image.registry`                | Substra event app image registry                     | `ghcr.io`                 |
+| `api.events.image.repository`              | Substra event app image repository                   | `substra/substra-backend` |
+| `api.events.image.tag`                     | Substra event app image tag (defaults to AppVersion) | `nil`                     |
+| `api.events.image.pullPolicy`              | Substra event app image pull policy                  | `IfNotPresent`            |
+| `api.events.image.pullSecrets`             | Specify image pull secrets                           | `[]`                      |
+| `api.events.podSecurityContext.enabled`    | Enable security context                              | `true`                    |
+| `api.events.podSecurityContext.runAsUser`  | User ID for the pod                                  | `1001`                    |
+| `api.events.podSecurityContext.runAsGroup` | Group ID for the pod                                 | `1001`                    |
+| `api.events.podSecurityContext.fsGroup`    | FileSystem group ID for the pod                      | `1001`                    |
+| `api.events.nodeSelector`                  | Node labels for pod assignment                       | `{}`                      |
+| `api.events.tolerations`                   | Toleration labels for pod assignment                 | `[]`                      |
+| `api.events.affinity`                      | Affinity settings for pod assignment                 | `{}`                      |
+| `api.events.rbac.create`                   | Create a role and service account for the event app  | `true`                    |
+| `api.events.serviceAccount.create`         | Create a service account for the event app           | `true`                    |
+| `api.events.serviceAccount.name`           | The name of the ServiceAccount to use                | `""`                      |
 
 
 ### Orchestrator settings

--- a/charts/substra-backend/templates/_helpers.tpl
+++ b/charts/substra-backend/templates/_helpers.tpl
@@ -175,3 +175,17 @@ Return the user list
     {{ default "default" .Values.api.events.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the proper image name, with option for a default tag
+example:
+    {{ include "substra-backend.images.name" (dict "img" .Values.path.to.the.image "defaultTag" $.Chart.AppVersion) }}
+*/}}
+{{- define "substra-backend.images.name" -}}
+    {{- $tag := (.img.tag | default .defaultTag) }}
+    {{- if .img.registry -}}
+    {{- printf "%s/%s:%s" .img.registry .img.repository $tag -}}
+    {{- else -}}
+    {{- printf "%s:%s" .img.repository $tag -}}
+    {{- end -}}
+{{- end -}}

--- a/charts/substra-backend/templates/deployment-api-events.yaml
+++ b/charts/substra-backend/templates/deployment-api-events.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: {{ include "substra.api.events.serviceAccountName" . }}
       containers:
         - name: api-event-app
-          image: {{ include "common.images.name" .Values.api.events.image }}
+          image: {{ include "substra-backend.images.name" (dict "img" .Values.api.events.image "defaultTag" $.Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.api.events.image.pullPolicy }}
           command: ["/bin/bash"]
           {{- if eq .Values.settings "prod" }}
@@ -113,7 +113,7 @@ spec:
           image: jwilder/dockerize:0.6.1
           command: ['dockerize', '-wait', 'tcp://{{ template  "postgresql.serviceName" . }}:5432']
         - name: wait-init-migrations
-          image: {{ include "common.images.name" .Values.api.events.image }}
+          image: {{ include "substra-backend.images.name" (dict "img" .Values.api.events.image "defaultTag" $.Chart.AppVersion) }}
           command: ['bash', '/usr/src/app/wait-init-migration.sh']
           volumeMounts:
             - name: volume-wait-init-migrations

--- a/charts/substra-backend/templates/deployment-scheduler-worker.yaml
+++ b/charts/substra-backend/templates/deployment-scheduler-worker.yaml
@@ -42,7 +42,7 @@ spec:
       {{- end }}
       containers:
         - name: scheduler-worker
-          image: {{ include "common.images.name" .Values.schedulerWorker.image }}
+          image: {{ include "substra-backend.images.name" (dict "img" .Values.schedulerWorker.image "defaultTag" $.Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.schedulerWorker.image.pullPolicy }}
           command: ["/bin/bash"]
           args: ["-c", "celery -A backend worker -l info -n {{ .Values.organizationName }} -Q {{ .Values.organizationName }},scheduler,celery --hostname {{ .Values.organizationName }}.scheduler"]

--- a/charts/substra-backend/templates/deployment-scheduler.yaml
+++ b/charts/substra-backend/templates/deployment-scheduler.yaml
@@ -39,7 +39,7 @@ spec:
       {{- end }}
       containers:
         - name: scheduler
-          image: {{ include "common.images.name" .Values.scheduler.image }}
+          image: {{ include "substra-backend.images.name" (dict "img" .Values.scheduler.image "defaultTag" $.Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.scheduler.image.pullPolicy }}
           command: ["/bin/bash"]
           args: ["-c", "celery -A backend beat -l debug"]

--- a/charts/substra-backend/templates/deployment-server.yaml
+++ b/charts/substra-backend/templates/deployment-server.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
       - name: server
-        image: {{ include "common.images.name" .Values.server.image }}
+        image: {{ include "substra-backend.images.name" (dict "img" .Values.server.image "defaultTag" $.Chart.AppVersion) }}
         imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
         command: ["/bin/bash"]
         {{- if eq .Values.settings "prod" }}
@@ -132,7 +132,7 @@ spec:
           {{- toYaml .Values.server.resources | nindent 12 }}
       {{- if .Values.server.metrics.enabled }}
       - name: metrics-sidecar
-        image: {{ include "common.images.name" .Values.server.metrics.image }}
+        image: {{ include "substra-backend.images.name" (dict "img" .Values.server.metrics.image "defaultTag" $.Chart.AppVersion) }}
         imagePullPolicy: {{ .Values.server.metrics.image.pullPolicy }}
         command: ["/bin/bash"]
         args:
@@ -185,7 +185,7 @@ spec:
         image: jwilder/dockerize:0.6.1
         command: ['dockerize', '-wait', 'tcp://{{ .Release.Name }}-minio:9000']
       - name: init-migrate
-        image: {{ include "common.images.name" .Values.server.image }}
+        image: {{ include "substra-backend.images.name" (dict "img" .Values.server.image "defaultTag" $.Chart.AppVersion) }}
         command: ['python', 'manage.py', 'migrate']
         envFrom:
           - configMapRef:
@@ -202,7 +202,7 @@ spec:
         - name: DJANGO_SETTINGS_MODULE
           value: backend.settings.{{ .Values.settings }}
       - name: init-collectstatic
-        image: {{ include "common.images.name" .Values.server.image }}
+        image: {{ include "substra-backend.images.name" (dict "img" .Values.server.image "defaultTag" $.Chart.AppVersion) }}
         command: ['python', 'manage.py', 'collectstatic', '--noinput']
         envFrom:
           - configMapRef:

--- a/charts/substra-backend/templates/deployment-worker-events.yaml
+++ b/charts/substra-backend/templates/deployment-worker-events.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: {{ include "substra.worker.events.serviceAccountName" . }}
       containers:
         - name: worker-event-app
-          image: {{ include "common.images.name" .Values.worker.events.image }}
+          image: {{ include "substra-backend.images.name" (dict "img" .Values.worker.events.image "defaultTag" $.Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.worker.events.image.pullPolicy }}
           command: ["/bin/bash"]
           {{- if eq .Values.settings "prod" }}
@@ -113,7 +113,7 @@ spec:
           image: jwilder/dockerize:0.6.1
           command: ['dockerize', '-wait', 'tcp://{{ template  "postgresql.serviceName" . }}:5432']
         - name: wait-init-migrations
-          image: {{ include "common.images.name" .Values.worker.events.image }}
+          image: {{ include "substra-backend.images.name" (dict "img" .Values.worker.events.image "defaultTag" $.Chart.AppVersion) }}
           command: ['bash', '/usr/src/app/wait-init-migration.sh']
           volumeMounts:
             - name: volume-wait-init-migrations

--- a/charts/substra-backend/templates/job-migrations.yaml
+++ b/charts/substra-backend/templates/job-migrations.yaml
@@ -27,7 +27,7 @@ spec:
       {{- end }}
       containers:
       - name: db-migrations
-        image: {{ include "common.images.name" .Values.server.image }}
+        image: {{ include "substra-backend.images.name" (dict "img" .Values.server.image "defaultTag" $.Chart.AppVersion) }}
         imagePullPolicy: {{ .Values.server.image.pullPolicy }}
         command: ["/bin/bash", "-c"]
         args:

--- a/charts/substra-backend/templates/statefulset-worker.yaml
+++ b/charts/substra-backend/templates/statefulset-worker.yaml
@@ -105,7 +105,7 @@ spec:
         command: ['dockerize', '-wait', 'tcp://{{ .Release.Name }}-minio:9000']
       containers:
         - name: worker
-          image: {{ include "common.images.name" .Values.worker.image }}
+          image: {{ include "substra-backend.images.name" (dict "img" .Values.worker.image "defaultTag" $.Chart.AppVersion) }}
           imagePullPolicy: "{{ .Values.worker.image.pullPolicy }}"
           command: ["/bin/bash"]
           {{- if eq .Values.settings "prod" }}

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -59,14 +59,14 @@ server:
   ## Substra backend image version
   ## @param server.image.registry Substra backend server image registry
   ## @param server.image.repository Substra backend server image repository
-  ## @param server.image.tag Substra backend server image tag
+  ## @param server.image.tag Substra backend server image tag (defaults to AppVersion)
   ## @param server.image.pullPolicy Substra backend server image pull policy
   ## @param server.image.pullSecrets Specify image pull secrets
   ##
   image:
     registry: ghcr.io
     repository: substra/substra-backend
-    tag: &backend-image-tag 0.35.1
+    tag: null
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be created manually in the namespace.
@@ -236,13 +236,13 @@ server:
     ## Metrics exporter image version
     ## @param server.metrics.image.registry Substra backend server Prometheus Exporter image registry
     ## @param server.metrics.image.repository Substra backend server Prometheus Exporter image repository
-    ## @param server.metrics.image.tag Substra backend server Prometheus Exporter image tag
+    ## @param server.metrics.image.tag Substra backend server Prometheus Exporter image tag (defaults to AppVersion)
     ## @param server.metrics.image.pullPolicy Substra backend server Prometheus Exporter image pull policy
     ##
     image:
       registry: ghcr.io
       repository: substra/substra-backend-metrics-exporter
-      tag: *backend-image-tag
+      tag: null
       pullPolicy: IfNotPresent
 
     serviceMonitor:
@@ -282,14 +282,14 @@ worker:
   concurrency: 1
   ## @param worker.image.registry Substra backend worker image registry
   ## @param worker.image.repository Substra backend worker image repository
-  ## @param worker.image.tag Substra backend worker image tag
+  ## @param worker.image.tag Substra backend worker image tag (defaults to AppVersion)
   ## @param worker.image.pullPolicy Substra backend worker image pull policy
   ## @param worker.image.pullSecrets Specify image pull secrets
   ##
   image:
     registry: ghcr.io
     repository: substra/substra-backend
-    tag: *backend-image-tag
+    tag: null
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param worker.podSecurityContext.enabled Enable security context
@@ -341,14 +341,14 @@ worker:
     enabled: true
     ## @param worker.events.image.registry Substra event app image registry
     ## @param worker.events.image.repository Substra event app image repository
-    ## @param worker.events.image.tag Substra event app image tag
+    ## @param worker.events.image.tag Substra event app image tag (defaults to AppVersion)
     ## @param worker.events.image.pullPolicy Substra event app image pull policy
     ## @param worker.events.image.pullSecrets Specify image pull secrets
     ##
     image:
       registry: ghcr.io
       repository: substra/substra-backend
-      tag: *backend-image-tag
+      tag: null
       pullPolicy: IfNotPresent
       pullSecrets: []
     ## @param worker.events.podSecurityContext.enabled Enable security context
@@ -394,14 +394,14 @@ schedulerWorker:
   replicaCount: 1
   ## @param schedulerWorker.image.registry Substra backend tasks scheduler image registry
   ## @param schedulerWorker.image.repository Substra backend tasks scheduler image repository
-  ## @param schedulerWorker.image.tag Substra backend tasks scheduler image tag
+  ## @param schedulerWorker.image.tag Substra backend tasks scheduler image tag (defaults to AppVersion)
   ## @param schedulerWorker.image.pullPolicy Substra backend task scheduler image pull policy
   ## @param schedulerWorker.image.pullSecrets Specify image pull secrets
   ##
   image:
     registry: ghcr.io
     repository: substra/substra-backend
-    tag: *backend-image-tag
+    tag: null
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param schedulerWorker.nodeSelector Node labels for pod assignment
@@ -438,14 +438,14 @@ scheduler:
   replicaCount: 1
   ## @param scheduler.image.registry Subsra backend tasks scheduler image registry
   ## @param scheduler.image.repository Substra backend tasks scheduler image repository
-  ## @param scheduler.image.tag Substra backend tasks scheduler image tag
+  ## @param scheduler.image.tag Substra backend tasks scheduler image tag (defaults to AppVersion)
   ## @param scheduler.image.pullPolicy Substra backend task scheduler image pull policy
   ## @param scheduler.image.pullSecrets Specify image pull secrets
   ##
   image:
     registry: ghcr.io
     repository: substra/substra-backend
-    tag: *backend-image-tag
+    tag: null
     pullPolicy: IfNotPresent
     pullSecrets: []
   ## @param scheduler.resources Scheduler container resources requests and limits
@@ -507,14 +507,14 @@ api:
     enabled: true
     ## @param api.events.image.registry Substra event app image registry
     ## @param api.events.image.repository Substra event app image repository
-    ## @param api.events.image.tag Substra event app image tag
+    ## @param api.events.image.tag Substra event app image tag (defaults to AppVersion)
     ## @param api.events.image.pullPolicy Substra event app image pull policy
     ## @param api.events.image.pullSecrets Specify image pull secrets
     ##
     image:
       registry: ghcr.io
       repository: substra/substra-backend
-      tag: *backend-image-tag
+      tag: null
       pullPolicy: IfNotPresent
       pullSecrets: []
     ## @param api.events.podSecurityContext.enabled Enable security context


### PR DESCRIPTION
## Description

This adds a new helm "function" that defaults the image tag to the AppVersion if it is not provided.

The removes one spot where the app version needed to be copied at releases.

This is already in place on the frontend, I'd been meaning to port this to the other repos -- also see https://github.com/Substra/orchestrator/pull/159 which is this but for the orchestrator.

## How has this been tested?

Check it works the same way:
```
git switch main
helm template charts/substra-backend > old-render.yaml
git switch chore-helm/default-appversion
helm template charts/substra-backend > new-render.yaml
diff old-render.yaml new-render.yaml
```

I also tried `helm template charts/substra-backend --set server.image.tag=woop` to check it (and only it) was set the given value.


## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [x] documentation was updated
