### PR TITLE
feat: Change tasks & steps duration format in task profiling to microseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BREAKING: rename Algo to Function ([#573](https://github.com/Substra/substra-backend/pull/573))
 - Rename fields in export perf csv ([#593](https://github.com/Substra/substra-backend/pull/593))
+- Durations in task profiling formatted in microseconds instead of 'DD hh:mm:ss.uuuuuu' ([#598](https://github.com/Substra/substra-backend/pull/598))
 
 ## [0.35.1](https://github.com/Substra/substra-backend/releases/tag/0.35.1) 2023-02-16
 

--- a/backend/api/serializers/task_profiling.py
+++ b/backend/api/serializers/task_profiling.py
@@ -9,8 +9,6 @@ from api.models.task_profiling import ProfilingStep
 
 
 class ProfilingStepSerializer(serializers.ModelSerializer):
-    duration = serializers.SerializerMethodField()
-
     class Meta:
         model = ProfilingStep
         fields = [
@@ -22,8 +20,10 @@ class ProfilingStepSerializer(serializers.ModelSerializer):
         profiling_step, created = ProfilingStep.objects.update_or_create(**data)
         return profiling_step
 
-    def get_duration(self, obj):
-        return duration_microseconds(obj.duration)
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+        representation["duration"] = duration_microseconds(instance.duration)
+        return representation
 
 
 class TaskProfilingSerializer(serializers.ModelSerializer):

--- a/backend/api/serializers/task_profiling.py
+++ b/backend/api/serializers/task_profiling.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from django.utils.duration import duration_string
+from django.utils.duration import duration_microseconds
 from rest_framework import serializers
 
 from api.models import ComputeTask
@@ -9,6 +9,8 @@ from api.models.task_profiling import ProfilingStep
 
 
 class ProfilingStepSerializer(serializers.ModelSerializer):
+    duration = serializers.SerializerMethodField()
+
     class Meta:
         model = ProfilingStep
         fields = [
@@ -19,6 +21,9 @@ class ProfilingStepSerializer(serializers.ModelSerializer):
     def create(self, data):
         profiling_step, created = ProfilingStep.objects.update_or_create(**data)
         return profiling_step
+
+    def get_duration(self, obj):
+        return duration_microseconds(obj.duration)
 
 
 class TaskProfilingSerializer(serializers.ModelSerializer):
@@ -39,7 +44,7 @@ class TaskProfilingSerializer(serializers.ModelSerializer):
     def get_task_duration(self, obj: TaskProfiling) -> Union[str, None]:
         if obj.compute_task.start_date is not None and obj.compute_task.end_date is not None:
             duration = obj.compute_task.end_date - obj.compute_task.start_date
-            return duration_string(duration)
+            return duration_microseconds(duration)
         else:
             return None
 

--- a/backend/api/tests/views/test_views_task_profiling.py
+++ b/backend/api/tests/views/test_views_task_profiling.py
@@ -33,7 +33,7 @@ class TaskProfilingViewTests(APITestCase):
         self.expected_results = [
             {
                 "compute_task_key": str(self.train_task.key),
-                "execution_rundown": [{"duration": "00:00:10", "step": "step 1"}],
+                "execution_rundown": [{"duration": 10000000, "step": "step 1"}],
                 "task_duration": None,
             }
         ]
@@ -94,7 +94,7 @@ class TaskProfilingViewTestsBackend(APITestCase):
         expected_result = [
             {
                 "compute_task_key": str(task.key),
-                "execution_rundown": [{"duration": "00:00:20", "step": "custom_step"}],
+                "execution_rundown": [{"duration": 20000000, "step": "custom_step"}],
                 "task_duration": None,
             }
         ]


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->

<!-- Please include a summary of your changes. -->

Change durations format to microseconds for task duration & execution rundown steps in task profiling.

Companion PR : https://github.com/Substra/substra-frontend/pull/165

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
