### PR TITLE
docs: Small improvement of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,19 +236,13 @@ The Substra platform is built from several components (see the [architecture](ht
 - [substra-frontend](https://github.com/Substra/substra-frontend) is the frontend consuming the API exposed by the backend
 - [substra-tests](https://github.com/Substra/substra-tests) is the Substra end to end test suite
 
-## License
-
-This project is developed under the Apache License, Version 2.0 (Apache-2.0), located in the [LICENSE](./LICENSE) file.
-
-
-### Running the backend on arm64 architecture (apple chip)
-
+## Running the backend on arm64 architecture (apple chip)
 
 Tested with:
     * python 3.9.4
     * pip 22.0.4
 
-Currently only the dev mode is supported with this architecture.
+Currently, only the dev mode is supported with this architecture.
 
 1. uwsgi
 
@@ -258,3 +252,7 @@ sudo ln -s /Library/Developer/CommandLineTools/Library/Frameworks/Python3.framew
 ```
 
 2. Deploy with `skaffold run -p dev,arm64`
+
+## License
+
+This project is developed under the Apache License, Version 2.0 (Apache-2.0), located in the [LICENSE](./LICENSE) file.

--- a/README.md
+++ b/README.md
@@ -239,8 +239,9 @@ The Substra platform is built from several components (see the [architecture](ht
 ## Running the backend on arm64 architecture (apple chip)
 
 Tested with:
-    * python 3.9.4
-    * pip 22.0.4
+
+* python 3.9.4
+* pip 22.0.4
 
 Currently, only the dev mode is supported with this architecture.
 


### PR DESCRIPTION
## Description
Sorry for the very small PR, I saw the notice at the bottom the the readme and wondered "Why is that part of the License ?" and then realized the title had the wrong level, so just fixing this.

- Fix the level of title of `Running the backend on arm64 architecture`
- Ensure the License stays at the bottom, to be visible
- Missing comma
- fix `<ul>` RST syntax

## How has this been tested?

https://github.com/ewjoachim/substra-backend/blob/patch-1/README.md
Readme screenshot:
<img width="1136" alt="Capture d’écran 2023-02-22 à 23 48 09" src="https://user-images.githubusercontent.com/1457576/220777846-e8244eec-597a-41fb-b847-939aa617d2c4.png">


## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
	- [x] Not notable
- [x] documentation was updated <- technically, it has been indeed ;)

I hereby certify that I agree with the terms of the DCO, but signing-off my commit means I'd need to fork the repo and amend. If that's ok with you, I think a change of this scope might not be worth the effort :)