### PR TITLE
fix: improve perf loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]()
 
+
 ### Added
 
 - Add filters to performances export (#590)
@@ -14,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prefetch `function__inputs`, `function__outputs` in `ComputeTaskViewSet` ([#613](https://github.com/Substra/substra-backend/pull/613))
 - Prefetch `inputs`, `outputs`, `inputs__asset`, `outputs__assets`, `function__inputs` and  `function__outputs` in `CPTaskViewSet` ([#613](https://github.com/Substra/substra-backend/pull/613))
 - Add `ComputeTaskWithDetailsSerializer` as a full-view serializer (including inputs and outputs) ([#613](https://github.com/Substra/substra-backend/pull/613))
+- Prefetch `outputs` in `_PerformanceMetricSerializer` ([#611](https://github.com/Substra/substra-backend/pull/611))
 
 
 ### Changed
@@ -27,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - filter warnings in `pyproject.toml` for previous deprecation warning in `rest_framework_simplejwt` ([#612](https://github.com/Substra/substra-backend/pull/612))
 - model `TaskDataSample` and fields `ComputeTask.data_samples` / `DataManager.compute_tasks` ([#614](https://github.com/Substra/substra-backend/pull/614))
+- `data_samples_keys` in `_PerformanceComputeTaskSerializer` ([#611](https://github.com/Substra/substra-backend/pull/611))
 
 ## [0.35.1](https://github.com/Substra/substra-backend/releases/tag/0.35.1) 2023-02-16
 

--- a/backend/api/serializers/performance.py
+++ b/backend/api/serializers/performance.py
@@ -2,10 +2,8 @@ from rest_framework import serializers
 
 from api.models import ComputeTask
 from api.models import Function
-from api.models import FunctionOutput
 from api.models import Performance
 from api.serializers.utils import SafeSerializerMixin
-from orchestrator import common_pb2
 
 
 class PerformanceSerializer(serializers.ModelSerializer, SafeSerializerMixin):
@@ -43,16 +41,15 @@ class _PerformanceMetricSerializer(serializers.ModelSerializer):
         fields = ["key", "name", "output_identifier"]
 
     def get_output_identifier(self, obj):
-        try:
-            performance_output = FunctionOutput.objects.get(
-                function_id=obj.key, kind=common_pb2.AssetKind.Name(common_pb2.ASSET_PERFORMANCE)
-            )
-        except (FunctionOutput.MultipleObjectsReturned, FunctionOutput.DoesNotExist) as e:
+        outputs = obj.outputs.all()
+        outputs_count = len(outputs)
+        if outputs_count != 1:
             raise Exception(
-                f"Couldn't associate an output identifier to performance for function '{obj.key}', error : {e}"
+                f"Couldn't associate an output identifier to performance for function '{obj.key}',"
+                f" error : found {outputs_count} identifier instead of 1"
             )
 
-        return performance_output.identifier
+        return outputs[0].identifier
 
 
 class _PerformanceComputeTaskSerializer(serializers.ModelSerializer):

--- a/backend/api/tests/views/conftest.py
+++ b/backend/api/tests/views/conftest.py
@@ -6,6 +6,8 @@ import pytest
 from django import conf
 from rest_framework import test
 
+from api.models import ComputeTask
+from api.tests import asset_factory as factory
 from api.tests.common import AuthenticatedClient
 
 _CHANNEL_NAME: Final[str] = "mychannel"
@@ -31,3 +33,38 @@ def authenticated_client() -> test.APIClient:
 @pytest.fixture
 def api_client() -> test.APIClient:
     return test.APIClient()
+
+
+@pytest.fixture
+def create_compute_task():
+    def _create_compute_task(compute_plan, n_data_sample=4):
+        data_manager = factory.create_datamanager()
+        data_samples = [factory.create_datasample([data_manager]) for _ in range(n_data_sample)]
+        input_keys = {
+            "opener": [data_manager.key],
+            "datasamples": [data_sample.key for data_sample in data_samples],
+        }
+        function = factory.create_function(
+            inputs=factory.build_function_inputs(["datasamples", "opener", "model"]),
+            outputs=factory.build_function_outputs(["model", "performance"]),
+            name="simple function",
+        )
+        return factory.create_computetask(
+            compute_plan,
+            function,
+            inputs=factory.build_computetask_inputs(function, input_keys),
+            outputs=factory.build_computetask_outputs(function),
+            status=ComputeTask.Status.STATUS_DONE,
+        )
+
+    return _create_compute_task
+
+
+@pytest.fixture
+def create_compute_plan(create_compute_task):
+    def _create_compute_plan(n_task=20, n_data_sample=4):
+        compute_plan = factory.create_computeplan()
+        [create_compute_task(compute_plan, n_data_sample=n_data_sample) for _ in range(n_task)]
+        return compute_plan
+
+    return _create_compute_plan

--- a/backend/api/tests/views/test_views_computetask.py
+++ b/backend/api/tests/views/test_views_computetask.py
@@ -771,43 +771,6 @@ class GenericTaskViewTests(ComputeTaskViewTests):
         assert data["count"] == 1
 
 
-@pytest.fixture
-def create_compute_task():
-    def _create_compute_task(compute_plan, n_data_sample=4):
-        data_manager = factory.create_datamanager()
-        data_samples = [factory.create_datasample([data_manager]) for _ in range(n_data_sample)]
-        input_keys = {
-            "opener": [data_manager.key],
-            "datasamples": [data_sample.key for data_sample in data_samples],
-        }
-        function = factory.create_function(
-            inputs=factory.build_function_inputs(["datasamples", "opener", "model"]),
-            outputs=factory.build_function_outputs(["model"]),
-            name="simple function",
-        )
-        return factory.create_computetask(
-            compute_plan,
-            function,
-            inputs=factory.build_computetask_inputs(function, input_keys),
-            outputs=factory.build_computetask_outputs(function),
-            data_manager=data_manager,
-            data_samples=[data_sample.key for data_sample in data_samples],
-            status=ComputeTask.Status.STATUS_DONE,
-        )
-
-    return _create_compute_task
-
-
-@pytest.fixture
-def create_compute_plan(create_compute_task):
-    def _create_compute_plan(n_task=20, n_data_sample=4):
-        compute_plan = factory.create_computeplan()
-        [create_compute_task(compute_plan, n_data_sample=n_data_sample) for _ in range(n_task)]
-        return compute_plan
-
-    return _create_compute_plan
-
-
 @pytest.mark.django_db
 def test_n_plus_one_queries_compute_task_in_compute_plan(authenticated_client, create_compute_plan):
     """

--- a/backend/api/tests/views/test_views_performance.py
+++ b/backend/api/tests/views/test_views_performance.py
@@ -351,43 +351,6 @@ class PerformanceViewTests(APITestCase):
         self.assertTrue(status in str(content_list[1]))
 
 
-@pytest.fixture
-def create_compute_task():
-    def _create_compute_task(compute_plan, n_data_sample=4):
-        data_manager = factory.create_datamanager()
-        data_samples = [factory.create_datasample([data_manager]) for _ in range(n_data_sample)]
-        input_keys = {
-            "opener": [data_manager.key],
-            "datasamples": [data_sample.key for data_sample in data_samples],
-        }
-        function = factory.create_function(
-            inputs=factory.build_function_inputs(["datasamples", "opener", "model"]),
-            outputs=factory.build_function_outputs(["model", "performance"]),
-            name="simple function",
-        )
-        return factory.create_computetask(
-            compute_plan,
-            function,
-            inputs=factory.build_computetask_inputs(function, input_keys),
-            outputs=factory.build_computetask_outputs(function),
-            data_manager=data_manager,
-            data_samples=[data_sample.key for data_sample in data_samples],
-            status=ComputeTask.Status.STATUS_DONE,
-        )
-
-    return _create_compute_task
-
-
-@pytest.fixture
-def create_compute_plan(create_compute_task):
-    def _create_compute_plan(n_task=20, n_data_sample=4):
-        compute_plan = factory.create_computeplan()
-        [create_compute_task(compute_plan, n_data_sample=n_data_sample) for _ in range(n_task)]
-        return compute_plan
-
-    return _create_compute_plan
-
-
 @pytest.mark.django_db
 def test_n_plus_one_queries_performance_list(authenticated_client, create_compute_plan):
     # Dummy request, the fist request seems to trigger a caching system caching 4 requests

--- a/backend/api/tests/views/test_views_performance.py
+++ b/backend/api/tests/views/test_views_performance.py
@@ -362,7 +362,7 @@ def create_compute_task():
         }
         function = factory.create_function(
             inputs=factory.build_function_inputs(["datasamples", "opener", "model"]),
-            outputs=factory.build_function_outputs(["performance"]),
+            outputs=factory.build_function_outputs(["model", "performance"]),
             name="simple function",
         )
         return factory.create_computetask(

--- a/backend/api/views/performance.py
+++ b/backend/api/views/performance.py
@@ -5,6 +5,7 @@ from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import F
 from django.db.models import Prefetch
 from django.db.models import Q
+from django.db.models import Value
 from django.http import StreamingHttpResponse
 from django_filters.rest_framework import DateTimeFromToRangeFilter
 from django_filters.rest_framework import DjangoFilterBackend
@@ -45,13 +46,17 @@ class CPPerformanceViewSet(mixins.ListModelMixin, GenericViewSet):
             .annotate(
                 # List all existing tasks ranks for a given compute plan
                 compute_tasks_distinct_ranks=ArrayAgg(
-                    "compute_tasks__rank", distinct=True, filter=Q(compute_tasks__rank__isnull=False)
+                    "compute_tasks__rank",
+                    distinct=True,
+                    filter=Q(compute_tasks__rank__isnull=False),
+                    default=Value([]),
                 ),
                 # List all existing tasks round indexes for a given compute plan
                 compute_tasks_distinct_rounds=ArrayAgg(
                     "compute_tasks__metadata__round_idx",
                     distinct=True,
                     filter=Q(compute_tasks__metadata__round_idx__isnull=False),
+                    default=Value([]),
                 ),
             )
             .values("compute_tasks_distinct_ranks", "compute_tasks_distinct_rounds")


### PR DESCRIPTION
## Companion PR

- https://github.com/Substra/substra-frontend/pull/180

## Description

Try to improve loading in performance page. Two strategies have been put in place:

1. Using prefetch for FunctionOutput and using it in the serializer (instead of making a request for each function on FunctionOutput)
2. Removing `data_samples` from the request, as it doesn't seem to be used in the frontend.

The point 2 is more controversial, as it breaks the current architecture of returning linked data on eac hrequest. However, it implies reaching a n+ 3 level (as the data_samples are ordered on `api_taskdatasample.order`, which is maybe not needed .

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
