### PR TITLE
fix: test due to deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ filterwarnings = [
     "error",
     "ignore:'rest_framework_simplejwt.token_blacklist' defines default_app_config:DeprecationWarning",
     "ignore:(?s).*Implementing implicit namespace package:DeprecationWarning:pkg_resources",
+    "ignore:pkg_resources is deprecated as an API:DeprecationWarning:pkg_resources"
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ DJANGO_SETTINGS_MODULE = "backend.settings.test"
 addopts = "-n auto --cov=. --cov-config=../pyproject.toml -p no:unraisableexception"
 filterwarnings = [
     "error",
-    "ignore:'rest_framework_simplejwt.token_blacklist' defines default_app_config:DeprecationWarning",
     "ignore:(?s).*Implementing implicit namespace package:DeprecationWarning:pkg_resources",
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning:pkg_resources"
 ]


### PR DESCRIPTION
## Description

Add new deprecation to remove error in CI due to new deprecation warning set in `setuptools` version [67.5.0](https://setuptools.pypa.io/en/stable/history.html#v67-5-0)

## How has this been tested?

Local CI

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
