### PR TITLE
chore: filter warning from test configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ addopts = "-n auto --cov=. --cov-config=../pyproject.toml -p no:unraisableexcept
 filterwarnings = [
     "error",
     "ignore:(?s).*Implementing implicit namespace package:DeprecationWarning:pkg_resources",
-    "ignore:pkg_resources is deprecated as an API:DeprecationWarning:pkg_resources"
+    "ignore:pkg_resources is deprecated as an API:DeprecationWarning:pkg_resources",
+    "ignore:SelectableGroups dict interface is deprecated. Use select.:DeprecationWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Description
https://app.asana.com/0/1203124674173179/1204116295835466/f

Filter out the deprecation warning while waiting for the upstream library to fix their stuff.

## How has this been tested?

`make test` on python 3.10
