### PR TITLE
fix: avoid nil env vars in chart

### DIFF
--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 22.4.1
+
+### Fixed
+- Fix OIDC values resulting in invalid manifests in some cases
+
 ## 22.4.0
 
 ### Added

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: substra-backend
 home: https://github.com/Substra
-version: 22.4.0
+version: 22.4.1
 appVersion: 0.35.1
 kubeVersion: ">= 1.19.0-0"
 description: Main package for Substra

--- a/charts/substra-backend/templates/configmap-oidc.yaml
+++ b/charts/substra-backend/templates/configmap-oidc.yaml
@@ -7,13 +7,13 @@ metadata:
 data:
   OIDC_ENABLED: {{ .Values.oidc.enabled | quote }}
   OIDC_USERS_APPEND_DOMAIN: {{ .Values.oidc.users.appendDomain | quote }}
-  OIDC_USERS_DEFAULT_CHANNEL: {{ .Values.oidc.users.channel | quote }}
-  OIDC_USERS_LOGIN_VALIDITY_DURATION: {{ .Values.oidc.users.loginValidityDuration | quote }}
+  OIDC_USERS_DEFAULT_CHANNEL: {{ .Values.oidc.users.channel | default "" | quote }}
+  OIDC_USERS_LOGIN_VALIDITY_DURATION: {{ .Values.oidc.users.loginValidityDuration | default "" | quote }}
   OIDC_USERS_USE_REFRESH_TOKEN: {{ .Values.oidc.users.useRefreshToken | quote }}
-  OIDC_RP_SIGN_ALGO: {{ .Values.oidc.signAlgo | quote }}
-  OIDC_OP_URL: {{ .Values.oidc.provider.url | quote }}
-  OIDC_OP_DISPLAY_NAME: {{ .Values.oidc.provider.displayName | quote }}
-  OIDC_OP_AUTHORIZATION_ENDPOINT: {{ .Values.oidc.provider.endpoints.authorization | quote }}
-  OIDC_OP_TOKEN_ENDPOINT: {{ .Values.oidc.provider.endpoints.token | quote }}
-  OIDC_OP_USER_ENDPOINT: {{ .Values.oidc.provider.endpoints.user | quote }}
-  OIDC_OP_JWKS_URI: {{ .Values.oidc.provider.jwksUri | quote }}
+  OIDC_RP_SIGN_ALGO: {{ .Values.oidc.signAlgo | default "" | quote }}
+  OIDC_OP_URL: {{ .Values.oidc.provider.url | default "" | quote }}
+  OIDC_OP_DISPLAY_NAME: {{ .Values.oidc.provider.displayName | default "" | quote }}
+  OIDC_OP_AUTHORIZATION_ENDPOINT: {{ .Values.oidc.provider.endpoints.authorization | default "" | quote }}
+  OIDC_OP_TOKEN_ENDPOINT: {{ .Values.oidc.provider.endpoints.token | default "" | quote }}
+  OIDC_OP_USER_ENDPOINT: {{ .Values.oidc.provider.endpoints.user | default "" | quote }}
+  OIDC_OP_JWKS_URI: {{ .Values.oidc.provider.jwksUri | default "" | quote }}

--- a/examples/values/backend-org-1.yaml
+++ b/examples/values/backend-org-1.yaml
@@ -75,7 +75,7 @@ addAccountOperator:
       channel: "yourchannel"
 
 oidc:
-  enabled: true
+  enabled: false
   clientSecretName: oidc-secret
   provider:
     url: "http://oidc-provider:4000"


### PR DESCRIPTION
## Description

This fixes an issue with #609 which broke the CI, basically

## How has this been tested?

e2e tests

## Checklist

- [x] Helm changelog updated
- [x] ~~[changelog](../CHANGELOG.md) was updated with notable changes~~ (no notable changes)
- [x] ~~documentation was updated~~ (nothing to document)
