### PR TITLE
chore: bump pytest-xdist to 3.2.1

### DIFF
--- a/backend/dev-requirements.txt
+++ b/backend/dev-requirements.txt
@@ -10,7 +10,7 @@ pep8-naming==0.13.2
 pytest-cov==4.0.0
 pytest-mock==3.8.2
 pytest-django==4.5.2
-pytest-xdist[psutil]==2.5.0
+pytest-xdist[psutil]==3.2.1
 pytest==7.2.0
 responses==0.21.0
 watchdog==2.1.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ filterwarnings = [
     "ignore:(?s).*Implementing implicit namespace package:DeprecationWarning:pkg_resources",
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning:pkg_resources",
     "ignore:SelectableGroups dict interface is deprecated. Use select.:DeprecationWarning",
+    # wait for pytest-cov to release a version > 4.0.0, see https://github.com/pytest-dev/pytest-xdist/issues/825#issuecomment-1292283870
+    "ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Description
Closes https://github.com/Substra/substra-backend/pull/629

Add a new warning filter because of https://github.com/pytest-dev/pytest-xdist/issues/825#issuecomment-1292341220 
<!-- Please reference issue if any. -->

<!-- Please include a summary of your changes. -->

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
