### PR TITLE
fix: enable Kaniko run layer caching

### DIFF
--- a/backend/substrapp/compute_tasks/image_builder.py
+++ b/backend/substrapp/compute_tasks/image_builder.py
@@ -291,6 +291,7 @@ def _build_container_args(dockerfile_mount_path: str, image_tag: str) -> list[st
         "--snapshotMode=redo",
         "--push-retry=3",
         "--cache-copy-layers",
+        "--cache-run-layers",
         "--log-format=text",
         f"--verbosity={('debug' if settings.LOG_LEVEL == 'DEBUG' else 'info')}",
     ]


### PR DESCRIPTION
## Description

Quoting [the Kaniko readme](https://github.com/GoogleContainerTools/kaniko#caching):

> kaniko can cache layers created by RUN(configured by flag --cache-run-layers) and COPY (configured by flag --cache-copy-layers) commands in a remote repository. Before executing a command, kaniko checks the cache for the layer. If it exists, kaniko will pull and extract the cached layer instead of executing the command. If not, kaniko will execute the command and then push the newly created layer to the cache.
>
> Note that kaniko cannot read layers from the cache after a cache miss: once a layer has not been found in the cache, all subsequent layers are built locally without consulting the cache.

Here are some Dockerfiles produced by SubstraFL. Each line is a layer:

<details>
<summary>As of writing</summary>

```Dockerfile
FROM ghcr.io/substra/substra-tools:0.20.0-nvidiacuda11.8.0-base-ubuntu22.04-python3.9

COPY . .

# install dependencies
RUN python3.9 -m pip install -U pip

# Install substrafl, substra (and substratools if editable mode)
RUN cd substrafl_internal/dist && python3.9 -m pip install substrafl-0.34.0-py3-none-any.whl

RUN cd substrafl_internal/dist && python3.9 -m pip install --force-reinstall substra-0.41.0-py3-none-any.whl

RUN cd substrafl_internal/dist && python3.9 -m pip install --force-reinstall substratools-0.20.0-py3-none-any.whl


# PyPi dependencies
RUN python3.9 -m pip install --no-cache-dir scikit-learn==1.1.1 numpy==1.23.1 torch torchvision pandas

# Install local dependencies


ENTRYPOINT ["python3.9", "function.py", "--function-name", "train"]

```

</details>

<details>
<summary>Proposed new version</summary>

This improves performance by moving often-changed layers down and copying wheels rather than recompiling them.

See https://github.com/Substra/substrafl/pull/110

```Dockerfile
FROM ghcr.io/substra/substra-tools:0.20.0-nvidiacuda11.8.0-base-ubuntu22.04-python3.9

# install dependencies
RUN python3.9 -m pip install -U pip

# PyPi dependencies
RUN python3.9 -m pip install --no-cache-dir scikit-learn==1.1.1 numpy==1.23.1 torch torchvision pandas

# Install substrafl, substra (and substratools if editable mode)
COPY substrafl_internal/dist/substrafl-0.34.0-py3-none-any.whl . 
RUN python3.9 -m pip install substrafl-0.34.0-py3-none-any.whl

COPY substrafl_internal/dist/substra-0.42.0-py3-none-any.whl . 
RUN python3.9 -m pip install --force-reinstall substra-0.42.0-py3-none-any.whl

COPY substrafl_internal/dist/substratools-0.20.0-py3-none-any.whl . 
RUN python3.9 -m pip install --force-reinstall substratools-0.20.0-py3-none-any.whl


# Install local dependencies


ENTRYPOINT ["python3.9", "function.py", "--function-name", "initialize"]

COPY . .
```
</details>

The important info is:
 - the `RUN` layers are very significant but are never cached
 - Kaniko stops looking in the cache after the first cache miss (which, in the current system, is the first line)

### potential problems

```
RUN python3.9 -m pip install --no-cache-dir scikit-learn==1.1.1 numpy==1.23.1 torch torchvision pandas
```

This layer is dangerous to cache, because, while the command stays the same, the result changes: the user expects the latest version of `torch`, `torchvision` and `pandas`, but if we're caching the result of this then the version won't change anymore

This is why run layer caching isn't enabled by default, and it means we have to be careful about constructing our images. This problem could be solved by SubstraFL fetching the latest versions of unpinned dependencies and pinning them in the generated Dockerfile, thus making it indempotent. 

The same issue is true with `COPY . .`, and I don't know how to fix that.

## How has this been tested?

This hasn't been tested yet

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
