### PR TITLE
feat: Add functionName to workflow view & allow ordering in tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]()
 
+### Added
+
+- Add function name to workflow view & ordering on functionName in cpTasks list (#635)
 
 ## [0.36.0](https://github.com/Substra/substra-backend/releases/tag/0.36.0) 2023-03-31
 
@@ -15,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add filters to performances export (#590)
 - Filter warnings in `pyproject.toml` to follow deprecation messages in `pkg_resources`([#612](https://github.com/Substra/substra-backend/pull/612))
 - Prefetch `function__inputs`, `function__outputs` in `ComputeTaskViewSet` ([#613](https://github.com/Substra/substra-backend/pull/613))
-- Prefetch `inputs`, `outputs`, `inputs__asset`, `outputs__assets`, `function__inputs` and  `function__outputs` in `CPTaskViewSet` ([#613](https://github.com/Substra/substra-backend/pull/613))
+- Prefetch `inputs`, `outputs`, `inputs__asset`, `outputs__assets`, `function__inputs` and `function__outputs` in `CPTaskViewSet` ([#613](https://github.com/Substra/substra-backend/pull/613))
 - Add `ComputeTaskWithDetailsSerializer` as a full-view serializer (including inputs and outputs) ([#613](https://github.com/Substra/substra-backend/pull/613))
 - Prefetch `outputs` in `_PerformanceMetricSerializer` ([#611](https://github.com/Substra/substra-backend/pull/611))
 - Index on `DataManager.channel` ([#607](https://github.com/Substra/substra-backend/pull/607))
@@ -25,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - order of `data_sample_key` in tests ([#607](https://github.com/Substra/substra-backend/pull/607))
-
 
 ### Changed
 

--- a/backend/api/tests/views/test_views_compute_plan_graph.py
+++ b/backend/api/tests/views/test_views_compute_plan_graph.py
@@ -130,6 +130,7 @@ class ComputePlanGraphViewTests(APITestCase):
                     "key": str(train_task.key),
                     "rank": 1,
                     "worker": "MyOrg1MSP",
+                    "function_name": "function",
                     "status": "STATUS_TODO",
                     "inputs_specs": [
                         {"kind": "ASSET_DATA_SAMPLE", "identifier": "datasamples"},
@@ -141,6 +142,7 @@ class ComputePlanGraphViewTests(APITestCase):
                     "key": str(predict_task.key),
                     "rank": 2,
                     "worker": "MyOrg1MSP",
+                    "function_name": "function",
                     "status": "STATUS_TODO",
                     "inputs_specs": [
                         {"kind": "ASSET_MODEL", "identifier": "model"},
@@ -151,6 +153,7 @@ class ComputePlanGraphViewTests(APITestCase):
                     "key": str(test_task.key),
                     "rank": 3,
                     "worker": "MyOrg1MSP",
+                    "function_name": "function",
                     "status": "STATUS_TODO",
                     "inputs_specs": [
                         {"kind": "ASSET_MODEL", "identifier": "predictions"},
@@ -161,6 +164,7 @@ class ComputePlanGraphViewTests(APITestCase):
                     "key": str(composite_task.key),
                     "rank": 10,
                     "worker": "MyOrg1MSP",
+                    "function_name": "function",
                     "status": "STATUS_TODO",
                     "inputs_specs": [
                         {"kind": "ASSET_DATA_SAMPLE", "identifier": "datasamples"},
@@ -172,6 +176,7 @@ class ComputePlanGraphViewTests(APITestCase):
                     "key": str(aggregate_task.key),
                     "rank": 11,
                     "worker": "MyOrg1MSP",
+                    "function_name": "function",
                     "status": "STATUS_TODO",
                     "inputs_specs": [
                         {"kind": "ASSET_MODEL", "identifier": "model"},

--- a/backend/api/views/compute_plan_graph.py
+++ b/backend/api/views/compute_plan_graph.py
@@ -61,8 +61,8 @@ def get_cp_graph(request, compute_plan_pk):
 
     tasks = (
         ComputeTask.objects.filter(compute_plan__key=compute_plan_pk, channel=get_channel_name(request))
-        .annotate(inputs_specs=Subquery(inputs), outputs_specs=Subquery(outputs))
-        .values("key", "rank", "worker", "status", "inputs_specs", "outputs_specs")
+        .annotate(inputs_specs=Subquery(inputs), outputs_specs=Subquery(outputs), function_name=F("function__name"))
+        .values("key", "rank", "function_name", "worker", "status", "inputs_specs", "outputs_specs")
     )
 
     # Set a task limitation for performances issues

--- a/backend/api/views/compute_plan_graph.py
+++ b/backend/api/views/compute_plan_graph.py
@@ -61,8 +61,10 @@ def get_cp_graph(request, compute_plan_pk):
 
     tasks = (
         ComputeTask.objects.filter(compute_plan__key=compute_plan_pk, channel=get_channel_name(request))
-        .annotate(inputs_specs=Subquery(inputs), outputs_specs=Subquery(outputs), function_name=F("function__name"))
-        .values("key", "rank", "function_name", "worker", "status", "inputs_specs", "outputs_specs")
+        # fetch_related not needed because annotate already performs a JOIN
+        .annotate(
+            inputs_specs=Subquery(inputs), outputs_specs=Subquery(outputs), function_name=F("function__name")
+        ).values("key", "rank", "function_name", "worker", "status", "inputs_specs", "outputs_specs")
     )
 
     # Set a task limitation for performances issues

--- a/backend/api/views/computetask.py
+++ b/backend/api/views/computetask.py
@@ -213,7 +213,7 @@ class ComputeTaskViewSetConfig:
         "owner",
         "rank",
         "status",
-        "worker",
+        "function__name",
         "tag",
         "compute_plan_key",
         "duration",


### PR DESCRIPTION
## Description

-  Adds function name to workflow view so that the frontend can display the function name for each task.
-  Allows ordering by function name in compute tasks list now that the frontend allow it. 

Companion PR : https://github.com/Substra/substra-frontend/pull/188

<!-- Please reference issue if any. -->

<!-- Please include a summary of your changes. -->

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
