### PR TITLE
fix: increase max attempts for kaniko and return logs instead of raising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]()
 
+### Fixed
+
+- Catch all exception in `get_pod_logs` and always return a string containing either logs, or the reason we couldn't get logs ([#637](https://github.com/Substra/substra-backend/pull/637))
+
+### Changed
+
+- Increase the `max_attempts` in `watch_log` to allow kaniko pods to take longer to start ([#637](https://github.com/Substra/substra-backend/pull/637))
+
 
 ## [0.36.0](https://github.com/Substra/substra-backend/releases/tag/0.36.0) 2023-03-31
 

--- a/backend/substrapp/compute_tasks/image_builder.py
+++ b/backend/substrapp/compute_tasks/image_builder.py
@@ -56,7 +56,7 @@ def build_image_if_missing(datastore: Datastore, function: orchestrator.Function
 
 def _build_function_image(asset: bytes, function: orchestrator.Function) -> None:
     """
-    Build an function's container image.
+    Build a function's container image.
 
     Perform multiple steps:
     1. Download the function using the provided asset storage_address/owner. Verify its checksum and uncompress the data

--- a/backend/substrapp/kubernetes_utils.py
+++ b/backend/substrapp/kubernetes_utils.py
@@ -90,8 +90,8 @@ def watch_pod(k8s_client: kubernetes.client.CoreV1Api, name: str):
         PodTimeoutError: this exception is raised if the pod does not reach the running state after some time
     """
     attempt = 0
-    # with 30 attempts we wait max 1 min with a pending pod
-    max_attempts = 30
+    # with 60 attempts we wait max 2 min with a pending pod
+    max_attempts = 60
 
     # This variable is used to track the current status through retries
     previous_pod_status = None
@@ -238,7 +238,9 @@ def get_pod_logs(k8s_client, name: str, container: str, ignore_pod_not_found: bo
     except kubernetes.client.ApiException as exc:
         if ignore_pod_not_found and exc.reason == "Not Found":
             return f"Pod not found: {NAMESPACE}/{name} ({container})"
-        raise
+        if exc.reason == "Bad Request":
+            return f"In {NAMESPACE}/{name} \n {str(exc.body)}"
+        return f"Unable to get logs for pod {NAMESPACE}/{name} ({container}) \n {str(exc)}"
 
 
 def delete_pod(k8s_client, name: str) -> None:


### PR DESCRIPTION
## Description

This PR does two things to patch instable behaviours in Kaniko observed lately. 
- Increase the number of attempts, hence the time we wait, in the [watch_pod](https://github.com/Substra/substra-backend/blob/e813ab5a71bb2051b508dcd741d1dce436305b8a/backend/substrapp/kubernetes_utils.py#L81) function.
- Catch exception raised by the [get_pod_logs](https://github.com/Substra/substra-backend/blob/e813ab5a71bb2051b508dcd741d1dce436305b8a/backend/substrapp/kubernetes_utils.py#L235), so that it does not crash the worker BEFORE deleting the kaniko pod it created. 

## How has this been tested?

Not yet, card created to add unit test as follow-up.

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
