### PR TITLE
fix: metrics exporter redis not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Catch all exception in `get_pod_logs` and always return a string containing either logs, or the reason we couldn't get logs ([#637](https://github.com/Substra/substra-backend/pull/637))
+- `redis` dependency for `metric-exporter` ([#640](https://github.com/Substra/substra-backend/pull/640))
+- Skaffold `monitoring` profile ([#640](https://github.com/Substra/substra-backend/pull/640))
 
 ### Changed
 

--- a/metrics-exporter/requirements.txt
+++ b/metrics-exporter/requirements.txt
@@ -1,3 +1,4 @@
 prometheus-client==0.16.0
 structlog==22.3.0
 celery==5.2.7
+redis==4.5.4

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -164,8 +164,11 @@ profiles:
         docker:
           dockerfile: docker/metrics-exporter/Dockerfile
     - op: add
-      path: /deploy/helm/releases/0/setValues/server.metrics.image
-      value: substra/metrics-exporter
+      path: /deploy/helm/releases/0/setValueTemplates/server.metrics.image
+      value: 
+        registry: '{{.IMAGE_DOMAIN_substra_metrics_exporter}}'
+        repository: '{{.IMAGE_REPO_NO_DOMAIN_substra_metrics_exporter}}'
+        tag: '{{.IMAGE_TAG_substra_metrics_exporter}}'
     - op: add
       path: /deploy/helm/releases/0/setValues/server.metrics.enabled
       value: True


### PR DESCRIPTION
## Description

Add `redis` in metrics_exporter dependencies to fix `server.metrics`

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated