### PR TITLE
fix: concurrent issuance of implicit bearer tokens

### DIFF
--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -48,6 +48,7 @@ class ObtainBearerToken(DRFObtainAuthToken):
         )
 
         token, just_created = ImplicitBearerToken.objects.get_or_create(user=user)
+        print(f"Debugging info {DEBUG_SESSION_ID}_D:", token.created, token.key, just_created)
         if not just_created:
             token = token.handle_expiration()
         return ApiResponse(ImplicitBearerTokenSerializer(token, include_payload=True).data)

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -8,6 +8,9 @@ from rest_framework.permissions import AllowAny
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.throttling import AnonRateThrottle
 from rest_framework.views import APIView
+from traceback import print_exception
+import random
+import string
 
 from api.views.utils import ApiResponse
 from api.views.utils import get_channel_name
@@ -33,10 +36,13 @@ class ObtainBearerToken(DRFObtainAuthToken):
         serializer = self.serializer_class(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
         user = serializer.validated_data["user"]
-        print("Debugging info A:", request.data)
-        print("Debugging info B:", type(user), user, user.id)
+        
+        DEBUG_SESSION_ID = ''.join(random.choices(string.ascii_uppercase, k=4))
+        
+        print(f"Debugging info {DEBUG_SESSION_ID}_A:", request.data)
+        print(f"Debugging info {DEBUG_SESSION_ID}_B:", type(user), user, user.id)
         print(
-            "Debugging info C:",
+            f"Debugging info {DEBUG_SESSION_ID}_C:",
             ImplicitBearerToken.objects.all(),
             [(it.created, it.is_expired) for it in ImplicitBearerToken.objects.all()],
         )
@@ -46,9 +52,11 @@ class ObtainBearerToken(DRFObtainAuthToken):
                 token = ImplicitBearerToken.objects.get(user=user)
                 token = token.handle_expiration()
             except ObjectDoesNotExist as e:
-                print("Debugging info ZA:", e)
-                print("Debugging info ZB")
+                print(f"Debugging info {DEBUG_SESSION_ID}_ZA:", e)
+                print_exception(e)
+                print(f"Debugging info {DEBUG_SESSION_ID}_ZB")
                 token = ImplicitBearerToken.objects.create(user=user)
+                print(f"Debugging info {DEBUG_SESSION_ID}_ZC:", token, token.user)
         return ApiResponse(ImplicitBearerTokenSerializer(token, include_payload=True).data)
 
 

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -53,7 +53,7 @@ class ObtainBearerToken(DRFObtainAuthToken):
                 token = token.handle_expiration()
             except ObjectDoesNotExist as e:
                 print(f"Debugging info {DEBUG_SESSION_ID}_ZA:", e)
-                traceback.format_exc()
+                print(traceback.format_exc())
                 print(f"Debugging info {DEBUG_SESSION_ID}_ZB")
                 token = ImplicitBearerToken.objects.create(user=user)
                 print(f"Debugging info {DEBUG_SESSION_ID}_ZC:", token, token.user)

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -47,16 +47,9 @@ class ObtainBearerToken(DRFObtainAuthToken):
             [(it.created, it.is_expired) for it in ImplicitBearerToken.objects.all()],
         )
 
-        with transaction.atomic():
-            try:
-                token = ImplicitBearerToken.objects.get(user=user)
-                token = token.handle_expiration()
-            except ObjectDoesNotExist as e:
-                print(f"Debugging info {DEBUG_SESSION_ID}_ZA:", e)
-                print(traceback.format_exc())
-                print(f"Debugging info {DEBUG_SESSION_ID}_ZB")
-                token = ImplicitBearerToken.objects.create(user=user)
-                print(f"Debugging info {DEBUG_SESSION_ID}_ZC:", token, token.user)
+        token, just_created = ImplicitBearerToken.objects.get_or_create(user=user)
+        if not just_created:
+            token = token.handle_expiration()
         return ApiResponse(ImplicitBearerTokenSerializer(token, include_payload=True).data)
 
 

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -8,7 +8,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.throttling import AnonRateThrottle
 from rest_framework.views import APIView
-from traceback import print_exception
+import traceback
 import random
 import string
 
@@ -53,7 +53,7 @@ class ObtainBearerToken(DRFObtainAuthToken):
                 token = token.handle_expiration()
             except ObjectDoesNotExist as e:
                 print(f"Debugging info {DEBUG_SESSION_ID}_ZA:", e)
-                print_exception(e)
+                traceback.format_exc()
                 print(f"Debugging info {DEBUG_SESSION_ID}_ZB")
                 token = ImplicitBearerToken.objects.create(user=user)
                 print(f"Debugging info {DEBUG_SESSION_ID}_ZC:", token, token.user)

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -32,6 +32,7 @@ class ObtainBearerToken(DRFObtainAuthToken):
         serializer = self.serializer_class(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
         user = serializer.validated_data["user"]
+        print("Debugging info:", request.data, user, user.id)
         try:
             token = ImplicitBearerToken.objects.get(user=user)
             token = token.handle_expiration()

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -32,11 +32,19 @@ class ObtainBearerToken(DRFObtainAuthToken):
         serializer = self.serializer_class(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
         user = serializer.validated_data["user"]
-        print("Debugging info:", request.data, user, user.id)
+        print("Debugging info A:", request.data)
+        print("Debugging info B:", type(user), user, user.id)
+        print(
+            "Debugging info C:",
+            ImplicitBearerToken.objects.all(),
+            [(it.created, it.is_expired) for it in ImplicitBearerToken.objects.all()],
+        )
         try:
             token = ImplicitBearerToken.objects.get(user=user)
             token = token.handle_expiration()
-        except ObjectDoesNotExist:
+        except ObjectDoesNotExist as e:
+            print("Debugging info ZA:", e)
+            print("Debugging info ZB")
             token = ImplicitBearerToken.objects.create(user=user)
         return ApiResponse(ImplicitBearerTokenSerializer(token, include_payload=True).data)
 

--- a/backend/users/models/token.py
+++ b/backend/users/models/token.py
@@ -40,6 +40,7 @@ class ImplicitBearerToken(Token):
         """
         if self.is_expired:
             self.delete()
+            print(f"Debugging info ({__name__}):", self)
             token = ImplicitBearerToken.objects.create(user=self.user)
             return token
         return self

--- a/backend/users/models/token.py
+++ b/backend/users/models/token.py
@@ -3,9 +3,10 @@ from datetime import datetime
 
 from django.conf import settings
 from django.db import models
+from django.db import transaction
 from django.utils import timezone
 from rest_framework.authtoken.models import Token
-from django.db import transaction
+
 
 class BearerToken(Token):
     note = models.TextField(null=True)


### PR DESCRIPTION
## Description

If an user who hasn't done so before makes multiple requests to `/api-token-auth` at the same time, the backend runs into concurrency issues and might error out due to database integrity violations.

This makes the whole operation atomic.

## How has this been tested?

⬇️ 

## Checklist

- [ ] ~~[changelog](../CHANGELOG.md) was updated with notable changes~~ -> no need since this should have been part of #639 and there have been no releases since
- [ ] ~~documentation was updated~~ -> no need
