### PR TITLE
chore: remove references to `substra` commands (namely `substra login`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BREAKING: Support for multiple API tokens with expanded functionality ([#639](https://github.com/Substra/substra-backend/pull/639))
 
+### Removed
+
+- references to `substra` cli commands in `localdev.md`  ([#667](https://github.com/Substra/substra-backend/pull/667))
+
 ## [0.37.0](https://github.com/Substra/substra-backend/releases/tag/0.37.0) 2023-05-11
 
 ### Changed

--- a/docs/localdev.md
+++ b/docs/localdev.md
@@ -32,14 +32,6 @@ docker run -it --name substra-backend --rm -p 8000:8000 \
 docker exec substra-backend python manage.py generate_fixtures
 ```
 
-Connect Substra client (`org-1` profile is used by Titanic example).
-
-```sh
-substra config --profile org-1 http://127.0.0.1:8000
-substra login --profile org-1 -u org-1 -p p@sswr0d44
-substra list --profile org-1 algo  # should display fixtures
-```
-
 ## (Optional) Restore a dump
 
 Warning: it will erase the database content (user, fixtures, etc).


### PR DESCRIPTION
## Related PR

- https://github.com/Substra/substra/pull/362

## Description

Remove references to `substra` commands in documentation

## Notes

Fixes FL-489

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
