### PR TITLE
chore: single dev DB creds

### DIFF
--- a/examples/values/backend-org-1.yaml
+++ b/examples/values/backend-org-1.yaml
@@ -9,10 +9,21 @@ config:
   LOG_LEVEL: DEBUG
 organizationName: MyOrg1
 
+# set the same creds as in localdev so they're the same everywhere in dev
+database:
+  auth:
+    username: &psql-username backend
+    password: &psql-password backend
+    database: &psql-database backend_default
+
 postgresql:
   primary:
     persistence:
       enabled: false
+  auth:
+    username: *psql-username
+    password: *psql-password
+    database: *psql-database
 
 redis:
   master:

--- a/examples/values/backend-org-2.yaml
+++ b/examples/values/backend-org-2.yaml
@@ -9,10 +9,21 @@ config:
   LOG_LEVEL: DEBUG
 organizationName: MyOrg2
 
+# set the same creds as in localdev so they're the same everywhere in dev
+database:
+  auth:
+    username: &psql-username backend
+    password: &psql-password backend
+    database: &psql-database backend_default
+
 postgresql:
   primary:
     persistence:
       enabled: false
+  auth:
+    username: *psql-username
+    password: *psql-password
+    database: *psql-database
 
 redis:
   master:


### PR DESCRIPTION
## Description

In #658, I removed alternative DB credentials from the server app.

This PR forces the DB settings to be the same in Skaffold as in localdev.

The main point of this is to make development a bit easier by always using the same credentials in all situations. Basically if you're developing on your machine the connection string will always be `postgresql://backend:backend@${HOST}/backend_default`, and `./manage.py shell` won't fail because you're on the profile with the wrong DB creds.

There are a lot of different development set-ups for Substra, so I think it's good to avoid having too much variance.

I'd agree the names (`backend:backend` and `backend_default`) aren't necessarily the best, but honestly I just want them to be the same everywhere.

## Checklist

- [-] ~~[changelog](../CHANGELOG.md) was updated with notable changes~~ (no user impact)
- [-] ~~documentation was updated~~ (no documentation to update)
