### PR TITLE
chore: release 0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.0](https://github.com/Substra/substra-backend/releases/tag/0.39.0) 2023-06-27
+
 ### Added
 
 - New `SECRET_KEY_PATH` and `SECRET_KEY_LOAD_AND_STORE` environment variables ([#668](https://github.com/Substra/substra-backend/pull/668))

--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [22.5.2] - 2023-06-27
+
+### Changed
+
+- Update substra-backend image tag to `0.39.0`
+
 ## 22.5.1
 
 ### Changed

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: substra-backend
 home: https://github.com/Substra
-version: 22.5.1
-appVersion: 0.38.0
+version: 22.5.2
+appVersion: 0.39.0
 kubeVersion: ">= 1.19.0-0"
 description: Main package for Substra
 type: application


### PR DESCRIPTION
## [0.39.0](https://github.com/Substra/substra-backend/releases/tag/0.39.0) 2023-06-27

### Added

- New `SECRET_KEY_PATH` and `SECRET_KEY_LOAD_AND_STORE` environment variables ([#668](https://github.com/Substra/substra-backend/pull/668))