### PR TITLE
feat: add force publish from substra-gha-workflows

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,6 +1,10 @@
 name: Docker build
 on:
   workflow_dispatch:
+    inputs:
+      force-publish:
+        description: Force publishing the image
+        type: boolean
   push:
     branches: [main]
   release:


### PR DESCRIPTION
## Description

Pass arguments from the `substra-gha-workflows` to `substra-backend` allowing publishing docker image from any commit.

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
