### PR TITLE
fix: remove pagination on `<task_id>/perf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove pagination on `get_performances` to remove limitation on 1000 first points ([#690](https://github.com/Substra/substra-backend/pull/690))
+
 ## [0.39.0](https://github.com/Substra/substra-backend/releases/tag/0.39.0) 2023-06-27
 
 ### Added

--- a/backend/api/tests/views/test_views_performance.py
+++ b/backend/api/tests/views/test_views_performance.py
@@ -118,9 +118,6 @@ class CPPerformanceViewTests(APITestCase):
         self.assertEqual(
             response.json(),
             {
-                "count": 0,
-                "next": None,
-                "previous": None,
                 "compute_plan_statistics": {
                     "compute_tasks_distinct_ranks": [1, 2, 3],
                     "compute_tasks_distinct_rounds": [1],
@@ -134,9 +131,6 @@ class CPPerformanceViewTests(APITestCase):
         self.assertEqual(
             response.json(),
             {
-                "count": len(self.expected_results),
-                "next": None,
-                "previous": None,
                 "compute_plan_statistics": self.expected_stats,
                 "results": self.expected_results,
             },


### PR DESCRIPTION
## Related issues

- https://github.com/Substra/substra/pull/372
- https://github.com/Substra/substra-frontend/pull/222

## Description

Remove pagination in performance endpoints, as we always need all of them. 

Note: alternative implementation would be to iterate on all pages in `<task_id>/perf/` in all case,  in the frontend and in the SDK.

Fixes FL-1092

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
