### PR TITLE
fix(helm): 22.6.0 changelog

### DIFF
--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [22.6.0] - 2023-07-18
 
 ### Added
 
-- New `requireApproval` field, that triggers the User Awaiting Approval functionality ([#680](https://github.com/Substra/substra-backend/pull/680))
+- New `oidc.users.requireApproval` field, that triggers the User Awaiting Approval functionality ([#680](https://github.com/Substra/substra-backend/pull/680))
 
 ## [22.5.2] - 2023-06-27
 


### PR DESCRIPTION
## Description

Fix the helm changelog featuring an "Unreleased" section (right now helm charts are released directly upon reaching `main`)

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [x] documentation was updated
