### PR TITLE
fix: exclude "external" from UserAwaitingApproval

### DIFF
--- a/backend/api/events/sync.py
+++ b/backend/api/events/sync.py
@@ -39,7 +39,7 @@ logger = structlog.get_logger(__name__)
 
 # dummy user to be referenced as creator for asset outside current organization
 def _get_or_create_external_user() -> User:
-    username = settings.EXTERNAL_USERNAME
+    username = settings.VIRTUAL_USERNAMES["EXTERNAL"]
     user_external, created = User.objects.get_or_create(username=username, is_active=False)
     if created:
         password = "".join(

--- a/backend/api/models/computeplan.py
+++ b/backend/api/models/computeplan.py
@@ -14,7 +14,7 @@ logger = structlog.get_logger(__name__)
 
 
 def _get_or_create_deleted_user() -> User:
-    user_deleted, created = User.objects.get_or_create(username=settings.DELETED_USERNAME, is_active=False)
+    user_deleted, created = User.objects.get_or_create(username=settings.VIRTUAL_USERNAMES["DELETED"], is_active=False)
     if created:
         password = "".join(
             (secrets.choice(string.ascii_letters + string.digits + string.punctuation) for _ in range(24))

--- a/backend/api/tests/views/test_views_computeplan.py
+++ b/backend/api/tests/views/test_views_computeplan.py
@@ -268,7 +268,7 @@ class ComputePlanViewTests(AuthenticatedAPITestCase):
         # asset creator should be deleted user
         url = reverse("api:compute_plan-detail", args=[key])
         response = self.client.get(url)
-        self.assertEqual(response.data["creator"], settings.DELETED_USERNAME)
+        self.assertEqual(response.data["creator"], settings.VIRTUAL_USERNAMES["DELETED"])
 
     def test_compute_plan_update(self):
         key = str(uuid.uuid4())

--- a/backend/backend/settings/common.py
+++ b/backend/backend/settings/common.py
@@ -335,8 +335,9 @@ ISOLATED = to_bool(os.environ.get("ISOLATED"))
 
 CONTENT_DISPOSITION_HEADER = {}
 
-# Username of additional Django user representing user external to organization
-EXTERNAL_USERNAME = "external"
-
-# Username of additional Django user representing deleted user to not break FK references
-DELETED_USERNAME = "deleted"
+VIRTUAL_USERNAMES = {
+    # Username of additional Django user representing user external to organization
+    "EXTERNAL": "external",
+    # Username of additional Django user representing deleted user to not break FK references
+    "DELETED": "deleted",
+}

--- a/backend/users/views/user.py
+++ b/backend/users/views/user.py
@@ -259,7 +259,7 @@ class UserAwaitingApprovalViewSet(
     filterset_class = UserFilter
 
     def get_queryset(self):
-        return self.user_model.objects.filter(channel=None).exclude(username="deleted")
+        return self.user_model.objects.filter(channel=None).exclude(username="deleted").exclude(username="external")
 
     def delete(self, request, *args, **kwargs):
         try:

--- a/backend/users/views/user.py
+++ b/backend/users/views/user.py
@@ -259,7 +259,7 @@ class UserAwaitingApprovalViewSet(
     filterset_class = UserFilter
 
     def get_queryset(self):
-        return self.user_model.objects.filter(channel=None).exclude(username="deleted").exclude(username="external")
+        return self.user_model.objects.filter(channel=None).exclude(username__in=settings.VIRTUAL_USERNAMES.values())
 
     def delete(self, request, *args, **kwargs):
         try:


### PR DESCRIPTION
## Description

one line PR to add an exclude as a fix to "external" users being considered as a UserAwaitingApproval

basically like "deleted" those username are the only kind of users allowed to not have a channel without beeing a UserAwaitingApproval

Fixes FL-989