### PR TITLE
chore: Increase workflow maxsize for frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase the number of tasks displayable in frontend workflow [#697](https://github.com/Substra/substra-backend/pull/697)
+
 ## [0.40.0](https://github.com/Substra/substra-backend/releases/tag/0.40.0) 2023-07-25
 
 ### Fixed

--- a/backend/api/views/compute_plan_graph.py
+++ b/backend/api/views/compute_plan_graph.py
@@ -21,7 +21,7 @@ Field.register_lookup(Any)
 
 logger = structlog.get_logger(__name__)
 
-MAX_TASKS_DISPLAYED = 1000
+MAX_TASKS_DISPLAYED = 5000
 
 
 class JsonbBuildObj(Func):


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->

<!-- Please include a summary of your changes. -->

Increase the number of tasks displayable in the frontend workflow from 1000 to 5000. 