### PR TITLE
chore!: rename the "message" field in API responses to "detail"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Increase the number of tasks displayable in frontend workflow [#697](https://github.com/Substra/substra-backend/pull/697)
+- BREAKING: Change the format of many API responses from `{"message":...}` to `{"detail":...}` ([#705](https://github.com/Substra/substra-backend/pull/705))
 
 ## [0.40.0](https://github.com/Substra/substra-backend/releases/tag/0.40.0) 2023-07-25
 

--- a/backend/api/errors.py
+++ b/backend/api/errors.py
@@ -12,15 +12,15 @@ class ApiError(Exception):
     """Base error response returned by API."""
 
     status = status.HTTP_500_INTERNAL_SERVER_ERROR
-    message = "Internal server error."
+    detail = "Internal server error."
 
-    def __init__(self, message=None, data=None):
-        message = message or self.message
+    def __init__(self, detail=None, data=None):
+        detail = detail or self.detail
 
         self.error = data or {}
-        self.error["message"] = message
+        self.error["detail"] = detail
 
-        super().__init__(message)
+        super().__init__(detail)
 
     def response(self):
         """Get HTTP Response from error instance."""
@@ -29,9 +29,9 @@ class ApiError(Exception):
 
 class BadRequestError(ApiError):
     status = status.HTTP_400_BAD_REQUEST
-    message = "Bad request."
+    detail = "Bad request."
 
 
 class AssetPermissionError(Exception):
-    def __init__(self, message="Unauthorized"):
-        super().__init__(self, message)
+    def __init__(self, detail="Unauthorized"):
+        super().__init__(self, detail)

--- a/backend/api/tests/views/test_exception_handler.py
+++ b/backend/api/tests/views/test_exception_handler.py
@@ -17,13 +17,13 @@ class ApiExceptionHandlerTests(unittest.TestCase):
         response = exception_handler.api_exception_handler(exc, None)
 
         self.assertEqual(response.status_code, orchestrator.error.RPC_TO_HTTP[code])
-        self.assertEqual(response.data["message"], details)
+        self.assertEqual(response.data["detail"], details)
 
     def test_catch_custom_validation_error(self):
-        message, key, status_code = "foo", "bar", status.HTTP_403_FORBIDDEN
-        exc = utils.ValidationExceptionError(message, key, status_code)
+        detail, key, status_code = "foo", "bar", status.HTTP_403_FORBIDDEN
+        exc = utils.ValidationExceptionError(detail, key, status_code)
         response = exception_handler.api_exception_handler(exc, None)
 
         self.assertEqual(response.status_code, status_code)
-        self.assertEqual(response.data["message"], message)
+        self.assertEqual(response.data["detail"], detail)
         self.assertEqual(response.data["key"], key)

--- a/backend/api/tests/views/test_views_datamanager.py
+++ b/backend/api/tests/views/test_views_datamanager.py
@@ -428,7 +428,7 @@ class DataManagerViewTests(APITestCase):
         response = self.client.post(self.url, data=data, format="multipart", **self.extra)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("File too large", response.data["message"][0]["data_opener"])
+        self.assertIn("File too large", response.data["detail"][0]["data_opener"])
 
         data["data_opener"].close()
         data["description"].close()

--- a/backend/api/tests/views/test_views_datasample.py
+++ b/backend/api/tests/views/test_views_datasample.py
@@ -334,7 +334,7 @@ class DataSampleViewTests(APITestCase):
             response = self.client.post(self.url, data=data, format="multipart", **self.extra)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("File too large", response.data["message"])
+        self.assertIn("File too large", response.data["detail"])
         data["file"].close()
 
     def test_datasample_create_fail_rollback(self):

--- a/backend/api/tests/views/test_views_function.py
+++ b/backend/api/tests/views/test_views_function.py
@@ -516,7 +516,7 @@ class FunctionViewTests(APITestCase):
         response = self.client.post(self.url, data=data, format="multipart")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("File too large", response.data["message"][0]["file"])
+        self.assertIn("File too large", response.data["detail"][0]["file"])
 
         data["description"].close()
         data["file"].close()

--- a/backend/api/views/compute_plan_graph.py
+++ b/backend/api/views/compute_plan_graph.py
@@ -70,7 +70,7 @@ def get_cp_graph(request, compute_plan_pk):
     # Set a task limitation for performances issues
     if len(tasks) > MAX_TASKS_DISPLAYED:
         return ApiResponse(
-            data={"message": f"Cannot build workflow graph for more than {MAX_TASKS_DISPLAYED} tasks."},
+            data={"detail": f"Cannot build workflow graph for more than {MAX_TASKS_DISPLAYED} tasks."},
             status=status.HTTP_403_FORBIDDEN,
         )
 

--- a/backend/api/views/datasample.py
+++ b/backend/api/views/datasample.py
@@ -49,7 +49,7 @@ def create(request, get_success_headers):
     #  not be caught to return a response. The following code only exists to preserve
     #  a previously established API contract.
     except serializers.ValidationError as e:
-        return ApiResponse({"message": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        return ApiResponse({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
     headers = get_success_headers(data)
     return ApiResponse(data, status=status.HTTP_201_CREATED, headers=headers)

--- a/backend/api/views/exception_handler.py
+++ b/backend/api/views/exception_handler.py
@@ -12,10 +12,10 @@ logger = structlog.get_logger(__name__)
 def api_exception_handler(exc, context):
     """API Exception handler."""
     if isinstance(exc, orchestrator.error.OrcError):
-        return response.Response({"message": exc.details}, status=exc.http_status)
+        return response.Response({"detail": exc.details}, status=exc.http_status)
 
     if isinstance(exc, utils.ValidationExceptionError):
-        return response.Response({"message": exc.data, "key": exc.key}, status=exc.st)
+        return response.Response({"detail": exc.data, "key": exc.key}, status=exc.st)
 
     if isinstance(exc, ApiError):
         # emits a warning for all requests returning an API error response

--- a/backend/api/views/utils.py
+++ b/backend/api/views/utils.py
@@ -82,7 +82,7 @@ class PermissionMixin(object):
 
     def download_file(self, request, asset_class, content_field, address_field):
         if settings.ISOLATED:
-            return ApiResponse({"message": "Asset not available in isolated mode"}, status=status.HTTP_410_GONE)
+            return ApiResponse({"detail": "Asset not available in isolated mode"}, status=status.HTTP_410_GONE)
         lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
         key = self.kwargs[lookup_url_kwarg]
         channel_name = get_channel_name(request)
@@ -93,11 +93,11 @@ class PermissionMixin(object):
         try:
             self.check_access(channel_name, request.user, asset, is_proxied_request(request))
         except AssetPermissionError as e:
-            return ApiResponse({"message": str(e)}, status=status.HTTP_403_FORBIDDEN)
+            return ApiResponse({"detail": str(e)}, status=status.HTTP_403_FORBIDDEN)
 
         url = getattr(asset, address_field)
         if not url:
-            return ApiResponse({"message": "Asset not available anymore"}, status=status.HTTP_410_GONE)
+            return ApiResponse({"detail": "Asset not available anymore"}, status=status.HTTP_410_GONE)
 
         if get_owner() == asset.get_owner():
             response = self._get_local_file_response(content_field)

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -84,10 +84,10 @@ class ActiveBearerTokens(APIView):
             token = BearerToken.objects.get(id=request.GET.get("id"))
             if request.user == token.user:
                 token.delete()
-                return ApiResponse(data={"message": "Token removed"}, status=status.HTTP_200_OK)
+                return ApiResponse(data={"detail": "Token removed"}, status=status.HTTP_200_OK)
         except BearerToken.ObjectDoesNotExist or BearerToken.MultipleObjectsReturned:
             pass
-        return ApiResponse(data={"message": "Token not found"}, status=status.HTTP_404_NOT_FOUND)
+        return ApiResponse(data={"detail": "Token not found"}, status=status.HTTP_404_NOT_FOUND)
 
 
 class Info(APIView):

--- a/backend/users/tests/test_user.py
+++ b/backend/users/tests/test_user.py
@@ -143,7 +143,7 @@ class TestUserEndpoints:
         response = AuthenticatedClient(role=UserChannel.Role.ADMIN, channel=self.channel).post(self.url, data=data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data.get("message") == "Username already exists"
+        assert response.data.get("detail") == "Username already exists"
 
     @pytest.mark.django_db
     def test_user_create_short_password(self):

--- a/backend/users/views/authentication.py
+++ b/backend/users/views/authentication.py
@@ -83,7 +83,7 @@ class AuthenticationViewSet(GenericViewSet):
         try:
             serializer.is_valid(raise_exception=True)
         except AuthenticationFailed:
-            return Response({"message": "wrong username password"}, status=status.HTTP_401_UNAUTHORIZED)
+            return Response({"detail": "wrong username password"}, status=status.HTTP_401_UNAUTHORIZED)
         except TokenError as e:
             raise InvalidToken(e.args[0])
 
@@ -104,7 +104,7 @@ class AuthenticationViewSet(GenericViewSet):
         try:
             serializer.is_valid(raise_exception=True)
         except AuthenticationFailed:
-            return Response({"message": "wrong username password"}, status=status.HTTP_401_UNAUTHORIZED)
+            return Response({"detail": "wrong username password"}, status=status.HTTP_401_UNAUTHORIZED)
         except TokenError as e:
             raise InvalidToken(e.args[0])
 

--- a/backend/users/views/user.py
+++ b/backend/users/views/user.py
@@ -72,9 +72,9 @@ def _validate_token(token, secret):
     try:
         jwt.decode(token, secret, algorithms=[settings.RESET_JWT_SIGNATURE_ALGORITHM])
     except (DecodeError, ExpiredSignatureError, InvalidTokenError) as err:
-        return {"is_valid": False, "message": err}
+        return {"is_valid": False, "detail": err}
 
-    return {"is_valid": True, "message": ""}
+    return {"is_valid": True, "detail": ""}
 
 
 def _save_password(view, instance, password):
@@ -185,7 +185,7 @@ class UserViewSet(
             data = _save_password(self, instance, password)
             return ApiResponse(data=data, status=status.HTTP_200_OK, headers=self.get_success_headers({}))
 
-        return ApiResponse(data={"message": "missing password in the request"}, status=status.HTTP_400_BAD_REQUEST)
+        return ApiResponse(data={"detail": "missing password in the request"}, status=status.HTTP_400_BAD_REQUEST)
 
     @action(methods=["post"], detail=True, permission_classes=[permissions.AllowAny], url_name="set-password")
     def set_password(self, request, *args, **kwargs):
@@ -204,7 +204,7 @@ class UserViewSet(
             return ApiResponse(data=data, status=status.HTTP_200_OK, headers=self.get_success_headers({}))
 
         return ApiResponse(
-            data={"message": "must provide a valid token to set a new password"},
+            data={"detail": "must provide a valid token to set a new password"},
             status=status.HTTP_401_UNAUTHORIZED,
         )
 
@@ -222,7 +222,7 @@ class UserViewSet(
             return ApiResponse(data={}, status=status.HTTP_200_OK, headers=self.get_success_headers({}))
 
         return ApiResponse(
-            data={"message": f"token not valid: {token_validation.get('message')}"},
+            data={"detail": f"token not valid: {token_validation.get('detail')}"},
             status=status.HTTP_401_UNAUTHORIZED,
         )
 
@@ -265,20 +265,20 @@ class UserAwaitingApprovalViewSet(
         try:
             user = User.objects.get(username=request.GET.get("username"))
             user.delete()
-            return ApiResponse(data={"message": "User removed"}, status=status.HTTP_200_OK)
+            return ApiResponse(data={"detail": "User removed"}, status=status.HTTP_200_OK)
         except User.DoesNotExist or User.MultipleObjectsReturned:
             pass
-        return ApiResponse(data={"message": "User not found"}, status=status.HTTP_404_NOT_FOUND)
+        return ApiResponse(data={"detail": "User not found"}, status=status.HTTP_404_NOT_FOUND)
 
     def put(self, request, *args, **kwargs):
         d = json.loads(request.body)
         try:
             user = User.objects.get(username=request.GET.get("username"))
         except User.DoesNotExist:
-            return ApiResponse(data={"message": "User not found"}, status=status.HTTP_404_NOT_FOUND)
+            return ApiResponse(data={"detail": "User not found"}, status=status.HTTP_404_NOT_FOUND)
         except User.MultipleObjectsReturned:
             return ApiResponse(
-                data={"message": "Multiple instance of the same user found"}, status=status.HTTP_409_CONFLICT
+                data={"detail": "Multiple instance of the same user found"}, status=status.HTTP_409_CONFLICT
             )
 
         channel_name = get_channel_name(request)


### PR DESCRIPTION
## Description

On error (HTTP 4XX or 5XX), our API's JSON reponses are inconsistent. This is in large part because our own code returns `{"message": ...}` but DRF returns `{"detail": ...}`.

This changes all instances were we use `message` to `detail` instead (including in non-error responses).

Companion PR: https://github.com/Substra/substra/pull/379

This PR replaces https://github.com/Substra/substra-backend/pull/699, a previous attempt at this

## How has this been tested?

I'm not sure how to test this works correctly :)

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [x] documentation was updated
