### PR TITLE
chore: replace deprecated kubernetes.io/ingress.class

### DIFF
--- a/examples/values/backend-org-1.yaml
+++ b/examples/values/backend-org-1.yaml
@@ -52,8 +52,8 @@ server:
   ingress:
     enabled: true
     hostname: "substra-backend.org-1.com"
+    ingressClassName: nginx
     annotations:
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/client-body-buffer-size: 100m
       nginx.ingress.kubernetes.io/proxy-body-size: 100m
       nginx.ingress.kubernetes.io/proxy-send-timeout: "120"

--- a/examples/values/backend-org-2.yaml
+++ b/examples/values/backend-org-2.yaml
@@ -52,8 +52,8 @@ server:
   ingress:
     enabled: true
     hostname: "substra-backend.org-2.com"
+    ingressClassName: nginx
     annotations:
-      kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/client-body-buffer-size: 100m
       nginx.ingress.kubernetes.io/proxy-body-size: 100m
       nginx.ingress.kubernetes.io/proxy-send-timeout: "120"


### PR DESCRIPTION
## Description

This removes this warning:

```
W0814 16:50:43.195377   70146 warnings.go:70] annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead
```

## How has this been tested?

`skaffold run`


## Checklist

- [x] ~~[changelog](../CHANGELOG.md) was updated with notable changes~~ (no notable changes)
- [x] ~~documentation was updated~~ (no documentation to update)
