### PR TITLE
chore: release 0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.0](https://github.com/Substra/substra-backend/releases/tag/0.41.0) 2023-09-07
+
 ### Added
+
 - New `SECRET_KEY` optional environment variable ([#671](https://github.com/Substra/substra-backend/pull/671))
 - `/api-token-auth/` and the associated tokens can now be disabled through the `EXPIRY_TOKEN_ENABLED` environment variable and `server.allowImplicitLogin` chart value ([#698](https://github.com/Substra/substra-backend/pull/698))
 - Tokens issued by `/api-token-auth/` can now be deleted like other API tokens, through a `DELETE` request on the `/active-api-tokens` endpoint ([#698](https://github.com/Substra/substra-backend/pull/698))
@@ -23,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed logic for storing `SECRET_KEY` at startup, in order to increase stability; it should be done at a higher level, i.e. the chart ([#671](https://github.com/Substra/substra-backend/pull/671))
 
 ## Fixed
+
 - `/api-token-auth/` sometimes handing out tokens that are about to expire ([#698](https://github.com/Substra/substra-backend/pull/698))
 
 ## [0.40.0](https://github.com/Substra/substra-backend/releases/tag/0.40.0) 2023-07-25

--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [22.8.1] - 2023-09-07
+
+### Changed
+
+- Update substra-backend image to `0.41.0`
+
 ## [22.8.0] - 2023-08-16
 
 ## Added
@@ -9,6 +15,7 @@
 ## [22.7.1] - 2023-08-16
 
 ### Changed
+
 - Created role no longer request superfluous permissions
 
 ## [22.7.0] - 2023-08-14

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: substra-backend
 home: https://github.com/Substra
-version: 22.8.0
-appVersion: 0.40.0
+version: 22.8.1
+appVersion: 0.41.0
 kubeVersion: ">= 1.19.0-0"
 description: Main package for Substra
 type: application


### PR DESCRIPTION
### Added

- New `SECRET_KEY` optional environment variable ([#671](https://github.com/Substra/substra-backend/pull/671))
- `/api-token-auth/` and the associated tokens can now be disabled through the `EXPIRY_TOKEN_ENABLED` environment variable and `server.allowImplicitLogin` chart value ([#698](https://github.com/Substra/substra-backend/pull/698))
- Tokens issued by `/api-token-auth/` can now be deleted like other API tokens, through a `DELETE` request on the `/active-api-tokens` endpoint ([#698](https://github.com/Substra/substra-backend/pull/698))

### Changed

- Increase the number of tasks displayable in frontend workflow [#697](https://github.com/Substra/substra-backend/pull/697)
- BREAKING: Change the format of many API responses from `{"message":...}` to `{"detail":...}` ([#705](https://github.com/Substra/substra-backend/pull/705))

### Removed

- BREAKING: `SECRET_KEY_PATH` and `SECRET_KEY_LOAD_AND_STORE` environment variables ([#671](https://github.com/Substra/substra-backend/pull/671))
- Removed logic for storing `SECRET_KEY` at startup, in order to increase stability; it should be done at a higher level, i.e. the chart ([#671](https://github.com/Substra/substra-backend/pull/671))

## Fixed

- `/api-token-auth/` sometimes handing out tokens that are about to expire ([#698](https://github.com/Substra/substra-backend/pull/698))