### PR TITLE
chore: add chart prerelease annotation for ArtifactHub 

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -97,11 +97,24 @@ jobs:
           version: "v3.12.0"
         id: install
 
+      - run: sudo snap install yq
+
       - name: Add dependencies repo
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add std-helm https://charts.helm.sh/stable
           helm repo add twuni https://helm.twun.io
+
+      - name: Mark chart as prerelease
+        # This avoids the chart being tagged as latest release on artifacthub
+        # see https://artifacthub.io/docs/topics/annotations/helm/
+        run: |
+          CHART_YAML_LOCATION=charts/substra-backend/Chart.yaml
+          if [ $(yq '.version | contains("-")' $CHART_YAML_LOCATION) == 'true' ]
+          then
+            yq '.annotations."artifacthub.io/prerelease" = "true"' $CHART_YAML_LOCATION > .Chart.yaml.new
+            mv .Chart.yaml.new $CHART_YAML_LOCATION
+          fi
 
       - name: Package chart
         run: |
@@ -118,7 +131,7 @@ jobs:
 
       - name: Publish chart
         run: |
-          mv substra-backend-$(grep -e "^version" charts/substra-backend/Chart.yaml | cut -c10-).tgz substra-charts/
+          mv substra-backend-$(yq ".version" charts/substra-backend/Chart.yaml).tgz substra-charts/
           cd substra-charts
           helm repo index .
           git add .

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -33,8 +33,3 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: 12.8.12
     condition: minio.enabled
-annotations:
-  # This avoids the chart being tagged as latest release on artifacthub
-  # see https://artifacthub.io/docs/topics/annotations/helm/
-  # REMOVE BEFORE MERGING INTO MAIN!
-  artifacthub.io/prerelease: "true"

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -33,3 +33,5 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: 12.8.12
     condition: minio.enabled
+annotations:
+  artifacthub.io/prerelease: "true"

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -34,4 +34,7 @@ dependencies:
     version: 12.8.12
     condition: minio.enabled
 annotations:
+  # This avoids the chart being tagged as latest release on artifacthub
+  # see https://artifacthub.io/docs/topics/annotations/helm/
+  # REMOVE BEFORE MERGING INTO MAIN!
   artifacthub.io/prerelease: "true"


### PR DESCRIPTION
## Description

ArtifactHub currently recommends checking out the alphas from this branch instead of our stable version.

They want a proprietary field being set: https://artifacthub.io/docs/topics/annotations/helm/

## Checklist

- [x] ~~[changelog](../CHANGELOG.md) was updated with notable changes~~ no notable changes
- [x] ~~documentation was updated~~ no documentation to update
