### PR TITLE
chore(ci): pass force-publish input to docker-build workflows

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -5,6 +5,8 @@ on:
       force-publish:
         description: Force publishing the image
         type: boolean
+        default: false
+        required: false
   push:
     branches: [main]
   release:
@@ -21,9 +23,11 @@ jobs:
     uses: substra/substra-gha-workflows/.github/workflows/docker-build.yaml@main
     with:
       image: substra-backend
+      force-publish: ${{ github.event.inputs.force-publish }}
   
   metrics-exporter:
     uses: substra/substra-gha-workflows/.github/workflows/docker-build.yaml@main
     with:
       image: substra-backend-metrics-exporter
       image-folder: metrics-exporter
+      force-publish: ${{ github.event.inputs.force-publish }}


### PR DESCRIPTION
## Description

The input was defined for manual runs but not passed to the `docker-build` from `substra/substra-gha-workflows`, it had no effect

<!-- Please include a summary of your changes. -->

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
