### PR TITLE
chore: bump psycopg2-binary from 2.9.3 to 2.9.9

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,7 +12,7 @@ drf-spectacular==0.25.1
 drf-nested-routers==0.93.4
 pyjwt==2.6.0
 kubernetes==26.1.0
-psycopg2-binary==2.9.3
+psycopg2-binary==2.9.9
 requests>=2.20.0
 uwsgi==2.0.22
 zxcvbn==4.4.28


### PR DESCRIPTION
## Description

issue with pip when installing 2.9.3

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
