### PR TITLE
fix: enforce use of `safezip` and `tarsafe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure that we always use `safezip` and `tarsafe` to avoid path traversal attack ([#845](https://github.com/Substra/substra-backend/pull/845))
+
 ## [0.43.0](https://github.com/Substra/substra-backend/releases/tag/0.43.0) 2024-02-26
 
 ### Added

--- a/backend/image_transfer/encoder.py
+++ b/backend/image_transfer/encoder.py
@@ -6,7 +6,6 @@ from typing import IO
 from typing import Iterator
 from typing import Optional
 from typing import Union
-from zipfile import ZipFile
 
 from dxf import DXF
 from dxf import DXFBase
@@ -20,11 +19,12 @@ from image_transfer.common import Manifest
 from image_transfer.common import PayloadDescriptor
 from image_transfer.common import PayloadSide
 from image_transfer.common import progress_as_string
+from substrapp.utils import safezip
 
 
 def add_blobs_to_zip(
     dxf_base: DXFBase,
-    zip_file: ZipFile,
+    zip_file: safezip.ZipFile,
     blobs_to_pull: list[Blob],
     blobs_already_transferred: list[Blob],
 ) -> dict[str, Union[BlobPathInZip, BlobLocationInRegistry]]:
@@ -54,7 +54,7 @@ def add_blobs_to_zip(
     return blobs_paths
 
 
-def download_blob_to_zip(dxf_base: DXFBase, blob: Blob, zip_file: ZipFile):
+def download_blob_to_zip(dxf_base: DXFBase, blob: Blob, zip_file: safezip.ZipFile):
     repository_dxf = DXF.from_base(dxf_base, blob.repository)
     bytes_iterator, total_size = repository_dxf.pull_blob(blob.digest, size=True)
 
@@ -99,7 +99,7 @@ def create_zip_from_docker_images(
     dxf_base: DXFBase,
     docker_images_to_transfer: list[str],
     docker_images_already_transferred: list[str],
-    zip_file: ZipFile,
+    zip_file: safezip.ZipFile,
     platform: Optional[str] = None,
 ) -> None:
     payload_descriptor = PayloadDescriptor.from_images(docker_images_to_transfer, docker_images_already_transferred)
@@ -156,7 +156,7 @@ def make_payload(
     authenticator = Authenticator(username, password)
 
     with DXFBase(host=registry, auth=authenticator.auth, insecure=not secure) as dxf_base:
-        with ZipFile(zip_file, "w") as zip_file_opened:
+        with safezip.ZipFile(zip_file, "w") as zip_file_opened:
             create_zip_from_docker_images(
                 dxf_base,
                 docker_images_to_transfer,

--- a/backend/substrapp/serializers/utils.py
+++ b/backend/substrapp/serializers/utils.py
@@ -1,12 +1,11 @@
-import tarfile
-import zipfile
-
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils.deconstruct import deconstructible
 from rest_framework import serializers
+from substrap.utils import tarsafe
 
 from substrapp.utils import raise_if_path_traversal
+from substrapp.utils import safezip
 
 
 @deconstructible
@@ -39,14 +38,12 @@ class FileValidator(object):
             raise ValidationError(self.error_messages["open"])
         else:
             try:
-                # is tarfile?
-                archive = tarfile.open(fileobj=data.file)
-            except tarfile.TarError:
-                # is zipfile?
-                if not zipfile.is_zipfile(data.file):
+                archive = tarsafe.open(fileobj=data.file)
+            except tarsafe.TarError:
+                if not safezip.is_zipfile(data.file):
                     raise ValidationError(self.error_messages["compressed"])
 
-                archive = zipfile.ZipFile(file=data.file)
+                archive = safezip.ZipFile(file=data.file)
                 self.validate_archive(archive.namelist())
             else:
                 self.validate_archive(archive.getnames())

--- a/backend/substrapp/serializers/utils.py
+++ b/backend/substrapp/serializers/utils.py
@@ -2,10 +2,10 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils.deconstruct import deconstructible
 from rest_framework import serializers
-from substrap.utils import tarsafe
 
 from substrapp.utils import raise_if_path_traversal
 from substrapp.utils import safezip
+from substrapp.utils import tarsafe
 
 
 @deconstructible

--- a/backend/substrapp/utils/__init__.py
+++ b/backend/substrapp/utils/__init__.py
@@ -4,9 +4,7 @@ import io
 import json
 import os
 import shutil
-import tarfile
 import time
-import zipfile
 from functools import wraps
 from os.path import isdir
 from os.path import isfile
@@ -18,8 +16,8 @@ import structlog
 from checksumdir import dirhash
 from django.conf import settings
 
+from substrapp.utils import safezip
 from substrapp.utils import tarsafe
-from substrapp.utils.safezip import ZipFile
 
 logger = structlog.get_logger(__name__)
 
@@ -95,11 +93,11 @@ def raise_if_path_traversal(requested_paths, to_directory):
 
 
 def uncompress_path(archive_path, to_directory):
-    if zipfile.is_zipfile(archive_path):
-        with ZipFile(archive_path, "r") as zf:
+    if safezip.is_zipfile(archive_path):
+        with safezip.ZipFile(archive_path, "r") as zf:
             zf.extractall(to_directory)
 
-    elif tarfile.is_tarfile(archive_path):
+    elif tarsafe.is_tarfile(archive_path):
         with tarsafe.open(archive_path, "r:*") as tf:
             tf.extractall(to_directory)
     else:
@@ -107,14 +105,14 @@ def uncompress_path(archive_path, to_directory):
 
 
 def uncompress_content(archive_content, to_directory):
-    if zipfile.is_zipfile(io.BytesIO(archive_content)):
-        with ZipFile(io.BytesIO(archive_content)) as zf:
+    if safezip.is_zipfile(io.BytesIO(archive_content)):
+        with safezip.ZipFile(io.BytesIO(archive_content)) as zf:
             zf.extractall(to_directory)
     else:
         try:
             with tarsafe.open(fileobj=io.BytesIO(archive_content)) as tf:
                 tf.extractall(to_directory)
-        except tarfile.TarError:
+        except tarsafe.TarError:
             raise Exception("Archive must be zip or tar.*")
 
 

--- a/backend/substrapp/utils/safezip.py
+++ b/backend/substrapp/utils/safezip.py
@@ -48,3 +48,6 @@ class ZipFile(zipfile.ZipFile):
 
     def _is_symlink(self, zipinfo: zipfile.ZipInfo) -> bool:
         return zipinfo.external_attr & stat.S_IFLNK << 16 == stat.S_IFLNK << 16
+
+
+is_zipfile = zipfile.is_zipfile

--- a/backend/substrapp/utils/tarsafe.py
+++ b/backend/substrapp/utils/tarsafe.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import tarfile
+from tarfile import TarError
 
 
 class TarSafe(tarfile.TarFile):
@@ -60,7 +61,7 @@ class TarSafe(tarfile.TarFile):
         return tarinfo.ischr() or tarinfo.isblk()
 
 
-class TarSafeError(Exception):
+class TarSafeError(TarError):
     pass
 
 


### PR DESCRIPTION
## Description

Fixes FL-1470

It will also unlock this dependency update (which nicely flagged it: https://github.com/Substra/substra-backend/pull/813)

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
