### PR TITLE
chore: run CI in 3.11

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.11
       - uses: actions/cache@v4.0.1
         id: cache
         with:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 Django==4.2.11
 structlog==24.1.0
 django-structlog==7.1.0
-celery==5.2.7
+celery==5.3.6
 checksumdir==1.2.0
 cryptography==42.0.5
 django-cors-headers==3.14.0


### PR DESCRIPTION
Run CI in 3.11 since our Docker image is based of 3.11