### PR TITLE
chore: allow alpha chart publication

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -12,7 +12,14 @@ on:
     paths:
       - "charts/**"
       - ".github/workflows/helm.yml"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      publish-alpha:
+        description: |
+          Publish alpha chart. Chart version must be X.Y.Z-alpha.N.
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -20,7 +27,8 @@ concurrency:
 
 jobs:
   test-generate-publish:
-      uses: substra/substra-gha-workflows/.github/workflows/helm.yml@main
+      uses: substra/substra-gha-workflows/.github/workflows/helm.yml@chore/allow-force-chart-publication
       secrets: inherit
       with:
         helm-repositories: '[{"name": "bitnami", "url": "https://charts.bitnami.com/bitnami"},{"name": "std-helm", "url": "https://charts.helm.sh/stable"},{"name": "twumi", "url": "https://helm.twun.io"},{"name": "localstack", "url": "https://localstack.github.io/helm-charts"}]'
+        publish-alpha: ${{ inputs.publish-alpha == true }}

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   test-generate-publish:
-      uses: substra/substra-gha-workflows/.github/workflows/helm.yml@chore/allow-force-chart-publication
+      uses: substra/substra-gha-workflows/.github/workflows/helm.yml@main
       secrets: inherit
       with:
         helm-repositories: '[{"name": "bitnami", "url": "https://charts.bitnami.com/bitnami"},{"name": "std-helm", "url": "https://charts.helm.sh/stable"},{"name": "twumi", "url": "https://helm.twun.io"},{"name": "localstack", "url": "https://localstack.github.io/helm-charts"}]'

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -11,7 +11,6 @@ on:
       - "main"
     paths:
       - "charts/**"
-      - ".github/workflows/helm.yml"
   workflow_dispatch:
     inputs:
       publish-alpha:


### PR DESCRIPTION
Companion:

- https://github.com/Substra/substra-backend/pull/881
- https://github.com/Substra/orchestrator/pull/405
- https://github.com/Substra/substra-frontend/pull/333

Example of working worklfow (with fake publish):

- https://github.com/Substra/substra-backend/actions/runs/8628929572