### PR TITLE
chore: remove building from task profiling

### DIFF
--- a/backend/substrapp/tasks/tasks_compute_task.py
+++ b/backend/substrapp/tasks/tasks_compute_task.py
@@ -66,7 +66,6 @@ logger = structlog.get_logger(__name__)
 
 
 class ComputeTaskSteps(enum.Enum):
-    BUILD_IMAGE = "build_image"
     PREPARE_INPUTS = "prepare_inputs"
     DOWNLOAD_FUNCTION = "download_function"
     TASK_EXECUTION = "task_execution"
@@ -195,12 +194,6 @@ def _run(
         init_asset_buffer()
         init_compute_plan_dirs(dirs)
         init_task_dirs(dirs)
-
-        # start build_image timer
-        timer.start()
-
-        # stop build_image timer
-        _create_task_profiling_step(channel_name, task.key, ComputeTaskSteps.BUILD_IMAGE, timer.stop())
 
         with acquire_compute_plan_lock(compute_plan_key):
             # Check the task/cp status again, as the task/cp may not be in a runnable state anymore

--- a/backend/substrapp/tests/tasks/test_compute_task.py
+++ b/backend/substrapp/tests/tasks/test_compute_task.py
@@ -213,7 +213,7 @@ def test_create_task_profiling_step_update(mock_retry: MagicMock, mocker: Mocker
     params = {
         "channel_name": CHANNEL,
         "compute_task_key": "42ff54eb-f4de-43b2-a1a0-a9f4c5f4737f",
-        "field": tasks_compute_task.ComputeTaskSteps.BUILD_IMAGE,
+        "field": tasks_compute_task.ComputeTaskSteps.PREPARE_INPUTS,
         "duration": datetime.timedelta(seconds=20),
     }
 

--- a/changes/1517.removed
+++ b/changes/1517.removed
@@ -1,0 +1,1 @@
+Task profiling step `build_image`


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->

<!-- Please include a summary of your changes. -->

Remove the task profiling step `build_image`. The function will get its own profiling with different steps in another contribution.

Fixes FL-1517

## Companion PR

- https://github.com/Substra/substra-frontend/pull/332

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
