### PR TITLE
chore: enforce pod security standards

### DIFF
--- a/backend/substrapp/kubernetes_utils.py
+++ b/backend/substrapp/kubernetes_utils.py
@@ -34,6 +34,7 @@ def get_security_context(root: bool = False, capabilities: list[str] = None) -> 
         privileged=False,
         allow_privilege_escalation=False,
         capabilities=kubernetes.client.V1Capabilities(drop=["ALL"], add=capabilities),
+        seccomp_profile=kubernetes.client.V1SeccompProfile(type="RuntimeDefault"),
     )
 
     if root:

--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 <!-- towncrier release notes start -->
 
+## [26.6.8] - 2024-06-06
+
+### Added
+
+- Pod and container security contexts (#895)
+
+### Changed
+
+- Updated bitnami charts to their latest version (#895)
+
 ## [26.6.7] - 2024-06-03
 
 

--- a/charts/substra-backend/Chart.lock
+++ b/charts/substra-backend/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 18.17.0
+  version: 19.5.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.16.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 13.1.2
+  version: 15.4.1
 - name: docker-registry
   repository: https://helm.twun.io
-  version: 2.2.2
+  version: 2.2.3
 - name: minio
   repository: https://charts.bitnami.com/bitnami
-  version: 12.8.12
+  version: 14.6.1
 - name: localstack
   repository: https://localstack.github.io/helm-charts
   version: 0.6.9
-digest: sha256:42c8f0dba9b2ab0b04533af995c5fb55fdb424fec68f9ce93ff697d861e84ac6
-generated: "2024-03-01T14:53:20.819977+01:00"
+digest: sha256:741c436098dd91e19b57ab423a3cf6befff017c76914af997c74b2c236064534
+generated: "2024-05-28T11:12:51.479028+02:00"

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: substra-backend
 home: https://github.com/Substra
-version: 26.6.7
+version: 26.6.8-alpha.1
 appVersion: 0.46.0
 kubeVersion: ">= 1.19.0-0"
 description: Main package for Substra
@@ -16,22 +16,22 @@ dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
-    version: 18.17.0
+    version: 19.5.0
   - name: common
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled,postgresql.enabled,minio.enabled
     version: 2.16.1
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 13.1.2
+    version: 15.4.1
     condition: postgresql.enabled
   - name: docker-registry
     repository: https://helm.twun.io
-    version: 2.2.2
+    version: 2.2.3
     condition: docker-registry.enabled
   - name: minio
     repository: https://charts.bitnami.com/bitnami
-    version: 12.8.12
+    version: 14.6.1
     condition: minio.enabled
   - name: localstack
     repository: https://localstack.github.io/helm-charts

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: substra-backend
 home: https://github.com/Substra
-version: 26.6.8-alpha.1
+version: 26.6.8
 appVersion: 0.46.0
 kubeVersion: ">= 1.19.0-0"
 description: Main package for Substra

--- a/charts/substra-backend/README.md
+++ b/charts/substra-backend/README.md
@@ -7,6 +7,14 @@ Substra Backend is a component of [Substra](https://github.com/SubstraFoundation
 - Kubernetes 1.19+
 - If you want to enable GPU support, install the nvidia device plugin for kubernetes: https://github.com/NVIDIA/k8s-device-plugin or https://github.com/NVIDIA/gpu-operator
 
+## Upgrading dependencies
+
+If you make changes to the versions of the external charts defined in `Chart.yaml`, you need to update the `Chart.lock` file by running:
+
+```bash
+helm dependency update
+```
+
 ## Changelog
 
 See [CHANGELOG.md](https://github.com/Substra/substra-backend/blob/main/charts/substra-backend/CHANGELOG.md)
@@ -192,7 +200,7 @@ See [UPGRADE.md](https://github.com/Substra/substra-backend/blob/main/charts/sub
 | ----------------------------------------- | ------------------------------------------------------------------ | ------------------------- |
 | `scheduler.enabled`                       | Enable scheduler service                                           | `true`                    |
 | `scheduler.replicaCount`                  | Replica count for the scheduler server                             | `1`                       |
-| `scheduler.image.registry`                | Subsra backend tasks scheduler image registry                      | `ghcr.io`                 |
+| `scheduler.image.registry`                | Substra backend tasks scheduler image registry                     | `ghcr.io`                 |
 | `scheduler.image.repository`              | Substra backend tasks scheduler image repository                   | `substra/substra-backend` |
 | `scheduler.image.tag`                     | Substra backend tasks scheduler image tag (defaults to AppVersion) | `nil`                     |
 | `scheduler.image.pullPolicy`              | Substra backend task scheduler image pull policy                   | `IfNotPresent`            |

--- a/charts/substra-backend/templates/_helpers.tpl
+++ b/charts/substra-backend/templates/_helpers.tpl
@@ -243,6 +243,13 @@ The hostname we should connect to (external is defined, otherwise integrated)
 {{- if or .Values.minio.enabled .Values.localstack.enabled }}
 - name: wait-minio
   image: jwilder/dockerize:0.6.1
+  securityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop: ["ALL"]
   command: ['dockerize', '-wait', 'tcp://{{ template "substra-backend.objectStore.url" .}}', '-timeout', '15s']
 {{- end }}
 {{- end -}}
@@ -254,6 +261,13 @@ The hostname we should connect to (external is defined, otherwise integrated)
 {{- define "common.waitPostgresqlInitContainer" -}}
 - name: wait-postgresql
   image: postgres
+  securityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop: ["ALL"]
   env:
    - name: PGUSER
      value: {{ .Values.database.auth.username }}
@@ -274,6 +288,7 @@ The hostname we should connect to (external is defined, otherwise integrated)
   imagePullPolicy: {{ .Values.privateCa.image.pullPolicy }}
   securityContext:
     runAsUser: 0
+    runAsNonRoot: false
   command: ['sh', '-c']
   args:
   - |
@@ -296,6 +311,13 @@ The hostname we should connect to (external is defined, otherwise integrated)
 {{- define "common.waitInitMigrationsInitContainer" -}}
 - name: wait-init-migrations
   image: {{ include "substra-backend.images.name" (dict "img" .Values.worker.events.image "defaultTag" $.Chart.AppVersion) }}
+  securityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop: ["ALL"]
   command: ['bash', '/usr/src/app/wait-init-migration.sh']
   volumeMounts:
   - name: volume-wait-init-migrations

--- a/charts/substra-backend/templates/deployment-api-events.yaml
+++ b/charts/substra-backend/templates/deployment-api-events.yaml
@@ -35,6 +35,9 @@ spec:
       {{- end }}
       {{- if .Values.api.events.podSecurityContext.enabled }}
       securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
         fsGroup: {{ .Values.api.events.podSecurityContext.fsGroup }}
         runAsUser: {{ .Values.api.events.podSecurityContext.runAsUser }}
         runAsGroup: {{ .Values.api.events.podSecurityContext.runAsGroup }}
@@ -46,6 +49,13 @@ spec:
           imagePullPolicy: {{ .Values.api.events.image.pullPolicy }}
           resources:
             {{- toYaml .Values.api.events.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
           command: ["/bin/bash"]
           {{- if eq .Values.settings "prod" }}
           args: ["-c", "python manage.py consume"]

--- a/charts/substra-backend/templates/deployment-registry-prepopulate.yaml
+++ b/charts/substra-backend/templates/deployment-registry-prepopulate.yaml
@@ -23,13 +23,27 @@ spec:
         role-internet-egress: 'true'
     spec:
       initContainers:
-      - name: wait-registry 
+      - name: wait-registry
         image: jwilder/dockerize:0.6.1
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: false
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop: ["ALL"]
         resources:
           {{- toYaml $.Values.registryPrepopulate.waitRegistry.resources | nindent 12 }}
         command: ['dockerize', '-wait', 'tcp://{{ $.Release.Name }}-docker-registry:5000']
       - name: kaniko
         image: {{ include "common.images.name" $.Values.kaniko.image }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: false
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop: ["ALL"]
         resources:
           {{- toYaml $.Values.kaniko.resources | nindent 12 }}
         args:
@@ -56,6 +70,13 @@ spec:
         name: pause
         resources:
           {{- toYaml $.Values.registryPrepopulate.pause.resources | nindent 12 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: false
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop: ["ALL"]
       volumes:
       - name: kaniko-dir
         emptyDir: {}

--- a/charts/substra-backend/templates/deployment-scheduler-worker.yaml
+++ b/charts/substra-backend/templates/deployment-scheduler-worker.yaml
@@ -33,6 +33,9 @@ spec:
     spec:
       {{- if .Values.schedulerWorker.podSecurityContext.enabled }}
       securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
         fsGroup: {{ .Values.schedulerWorker.podSecurityContext.fsGroup }}
         runAsUser: {{ .Values.schedulerWorker.podSecurityContext.runAsUser }}
         runAsGroup: {{ .Values.schedulerWorker.podSecurityContext.runAsGroup }}
@@ -48,6 +51,13 @@ spec:
         - name: scheduler-worker
           image: {{ include "substra-backend.images.name" (dict "img" .Values.schedulerWorker.image "defaultTag" $.Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.schedulerWorker.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
           command: ["/bin/bash"]
           args: ["-c", "celery -A backend worker -l info -n {{ .Values.organizationName }} -Q {{ .Values.organizationName }},scheduler,celery --hostname {{ .Values.organizationName }}.scheduler"]
           envFrom:

--- a/charts/substra-backend/templates/deployment-scheduler.yaml
+++ b/charts/substra-backend/templates/deployment-scheduler.yaml
@@ -37,6 +37,9 @@ spec:
       {{- end }}
       {{- if .Values.scheduler.podSecurityContext.enabled }}
       securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
         fsGroup: {{ .Values.scheduler.podSecurityContext.fsGroup }}
         runAsGroup: {{ .Values.scheduler.podSecurityContext.runAsGroup }}
         runAsUser: {{ .Values.scheduler.podSecurityContext.runAsUser }}
@@ -45,6 +48,13 @@ spec:
         - name: scheduler
           image: {{ include "substra-backend.images.name" (dict "img" .Values.scheduler.image "defaultTag" $.Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.scheduler.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
           command: ["/bin/bash"]
           args: ["-c", "celery -A backend beat -l debug --schedule /var/substra/runtime-db/celerybeat-scheduler"]
           envFrom:

--- a/charts/substra-backend/templates/deployment-server.yaml
+++ b/charts/substra-backend/templates/deployment-server.yaml
@@ -36,6 +36,9 @@ spec:
     spec:
       {{- if .Values.server.podSecurityContext.enabled }}
       securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
         fsGroup: {{ .Values.server.podSecurityContext.fsGroup }}
         runAsUser: {{ .Values.server.podSecurityContext.runAsUser }}
         runAsGroup: {{ .Values.server.podSecurityContext.runAsGroup }}
@@ -47,6 +50,13 @@ spec:
       containers:
       - name: server
         image: {{ include "substra-backend.images.name" (dict "img" .Values.server.image "defaultTag" $.Chart.AppVersion) }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop: ["ALL"]
         imagePullPolicy: "{{ .Values.server.image.pullPolicy }}"
         command: ["/bin/bash"]
         {{- if eq .Values.settings "prod" }}
@@ -153,6 +163,13 @@ spec:
       - name: metrics-sidecar
         image: {{ include "substra-backend.images.name" (dict "img" .Values.server.metrics.image "defaultTag" $.Chart.AppVersion) }}
         imagePullPolicy: {{ .Values.server.metrics.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop: ["ALL"]
         command: ["/bin/bash"]
         args:
           - "-c"
@@ -180,6 +197,13 @@ spec:
       - name: init-collectstatic
         image: {{ include "substra-backend.images.name" (dict "img" .Values.server.image "defaultTag" $.Chart.AppVersion) }}
         command: ['python', 'manage.py', 'collectstatic', '--noinput']
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop: ["ALL"]
         envFrom:
           - configMapRef:
               name: {{ include "substra.fullname" . }}-orchestrator
@@ -195,6 +219,13 @@ spec:
       - name: init-migrate
         image: {{ include "substra-backend.images.name" (dict "img" .Values.server.image "defaultTag" $.Chart.AppVersion) }}
         command: ['python', 'manage.py', 'migrate']
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop: ["ALL"]
         envFrom:
           - configMapRef:
               name: {{ include "substra.fullname" . }}-orchestrator

--- a/charts/substra-backend/templates/deployment-worker-events.yaml
+++ b/charts/substra-backend/templates/deployment-worker-events.yaml
@@ -36,9 +36,13 @@ spec:
       {{- end }}
       {{- if .Values.worker.events.podSecurityContext.enabled }}
       securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
         fsGroup: {{ .Values.worker.events.podSecurityContext.fsGroup }}
         runAsUser: {{ .Values.worker.events.podSecurityContext.runAsUser }}
         runAsGroup: {{ .Values.worker.events.podSecurityContext.runAsGroup }}
+
       {{- end }}
       serviceAccountName: {{ include "substra.worker.events.serviceAccountName" . }}
       containers:
@@ -47,6 +51,13 @@ spec:
           imagePullPolicy: {{ .Values.worker.events.image.pullPolicy }}
           resources:
             {{- toYaml .Values.worker.events.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
           command: ["/bin/bash"]
           {{- if eq .Values.settings "prod" }}
           args: ["-c", "python manage.py consume"]

--- a/charts/substra-backend/templates/job-migrations.yaml
+++ b/charts/substra-backend/templates/job-migrations.yaml
@@ -20,6 +20,9 @@ spec:
       automountServiceAccountToken: false
       {{- if .Values.server.podSecurityContext.enabled }}
       securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
         fsGroup: {{ .Values.server.podSecurityContext.fsGroup }}
         runAsUser: {{ .Values.server.podSecurityContext.runAsUser }}
         runAsGroup: {{ .Values.server.podSecurityContext.runAsGroup }}
@@ -30,6 +33,13 @@ spec:
       {{- end }}
       containers:
       - name: db-migrations
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop: ["ALL"]
         image: {{ include "substra-backend.images.name" (dict "img" .Values.server.image "defaultTag" $.Chart.AppVersion) }}
         imagePullPolicy: {{ .Values.server.image.pullPolicy }}
         command: ["/bin/bash", "-c"]

--- a/charts/substra-backend/templates/statefulset-builder.yaml
+++ b/charts/substra-backend/templates/statefulset-builder.yaml
@@ -53,6 +53,9 @@ spec:
     spec:
       {{- if .Values.builder.podSecurityContext.enabled }}
       securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
         fsGroup: {{ .Values.builder.podSecurityContext.fsGroup }}
         runAsUser: {{ .Values.builder.podSecurityContext.runAsUser }}
         runAsGroup: {{ .Values.builder.podSecurityContext.runAsGroup }}
@@ -70,6 +73,7 @@ spec:
         imagePullPolicy: {{ .Values.privateCa.image.pullPolicy }}
         securityContext:
           runAsUser: 0
+          runAsNonRoot: false
         command: ['sh', '-c']
         args:
         - |
@@ -88,6 +92,13 @@ spec:
       {{- include "common.waitMinIOContainer" . | nindent 6 }}
       {{- if .Values.kaniko.cache.warmer.cachedImages }}
       - name: kaniko-cache-warmer
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop: ["ALL"]
         image: {{ include "common.images.name" .Values.kaniko.cache.warmer.image }}
         args:
         - "--cache-dir=/cache"
@@ -108,6 +119,13 @@ spec:
       - name: builder
         image: {{ include "substra-backend.images.name" (dict "img" .Values.builder.image "defaultTag" $.Chart.AppVersion) }}
         imagePullPolicy: "{{ .Values.builder.image.pullPolicy }}"
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop: ["ALL"]
         command: ["/bin/bash", "-c"]
         {{- if eq .Values.settings "prod" }}
         args: ["celery -A backend worker -E -l info -Q {{ .Values.organizationName }}.builder,{{ .Values.organizationName }}.builder-${HOSTNAME##*-},{{ .Values.organizationName }}.broadcast --hostname {{ .Values.organizationName }}.builder-${HOSTNAME##*-}"]

--- a/charts/substra-backend/templates/statefulset-worker.yaml
+++ b/charts/substra-backend/templates/statefulset-worker.yaml
@@ -53,6 +53,9 @@ spec:
     spec:
       {{- if .Values.worker.podSecurityContext.enabled }}
       securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
         runAsUser: {{ .Values.worker.podSecurityContext.runAsUser }}
         runAsGroup: {{ .Values.worker.podSecurityContext.runAsGroup }}
         fsGroup: {{ .Values.worker.podSecurityContext.fsGroup }}
@@ -72,6 +75,13 @@ spec:
         - name: worker
           image: {{ include "substra-backend.images.name" (dict "img" .Values.worker.image "defaultTag" $.Chart.AppVersion) }}
           imagePullPolicy: "{{ .Values.worker.image.pullPolicy }}"
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: ["ALL"]
           command: ["/bin/bash"]
           {{- if eq .Values.settings "prod" }}
           args: ["-c", "celery -A backend worker -E -l info -Q {{ .Values.organizationName }}.worker,{{ .Values.organizationName }}.worker-${HOSTNAME##*-},{{ .Values.organizationName }}.broadcast,celery --hostname {{ .Values.organizationName }}.worker-${HOSTNAME##*-}"]

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -1000,6 +1000,8 @@ redis:
     appendonly yes
     # Disable RDB persistence since AOF persistence is enabled
     save ""
+  pdb:
+    create: false
 
 ## @skip docker-registry
 ##
@@ -1057,6 +1059,8 @@ minio:
       drop: [ "ALL" ]
     seccompProfile:
       type: "RuntimeDefault"
+  pdb:
+    create: false
 
 ## @skip localstack
 ##

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -488,7 +488,7 @@ scheduler:
   ## @param scheduler.replicaCount Replica count for the scheduler server
   ##
   replicaCount: 1
-  ## @param scheduler.image.registry Subsra backend tasks scheduler image registry
+  ## @param scheduler.image.registry Substra backend tasks scheduler image registry
   ## @param scheduler.image.repository Substra backend tasks scheduler image repository
   ## @param scheduler.image.tag Substra backend tasks scheduler image tag (defaults to AppVersion)
   ## @param scheduler.image.pullPolicy Substra backend task scheduler image pull policy
@@ -941,15 +941,6 @@ postgresql:
     database: *psql-database
   ## @skip postgresql.primary
   primary:
-    podSecurityContext:
-      runAsNonRoot: true
-      seccompProfile:
-        type: RuntimeDefault
-    containerSecurityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-        - ALL
     resources:
       requests:
         cpu: "1000m"
@@ -957,6 +948,20 @@ postgresql:
       limits:
         cpu: "1000m"
         memory: "4Gi"
+    podSecurityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      enabled: true
+      runAsUser: 1001
+      runAsGroup: 1001
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ "ALL" ]
+      seccompProfile:
+        type: "RuntimeDefault"
 
 ## @skip redis
 ##
@@ -978,6 +983,16 @@ redis:
       limits:
         cpu: "500m"
         memory: "1024Mi"
+    containerSecurityContext:
+      enabled: true
+      runAsUser: 1001
+      runAsGroup: 1001
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop: [ "ALL" ]
   replica:
     replicaCount: 0
   commonConfiguration: |-
@@ -1004,6 +1019,15 @@ docker-registry:
     limits:
       cpu: "500m"
       memory: "64Gi"
+  containerSecurityContext:
+    enabled: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
 
 ## @skip minio
 ##
@@ -1016,14 +1040,6 @@ minio:
     forcePassword: true
     ## required to take into account new access and secret keys
     forceNewKeys: true
-  podSecurityContext:
-    seccompProfile:
-      type: RuntimeDefault
-  containerSecurityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
   resources:
     requests:
       cpu: "500m"
@@ -1031,6 +1047,16 @@ minio:
     limits:
       cpu: "1000m"
       memory: "64Gi"
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+    runAsGroup: 1001
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: [ "ALL" ]
+    seccompProfile:
+      type: "RuntimeDefault"
 
 ## @skip localstack
 ##
@@ -1070,6 +1096,7 @@ localstack:
     enabled: true
     accessMode: ReadWriteOnce
     size: 5Gi
+
 ## @section Helm hooks
 ##
 hooks:


### PR DESCRIPTION
Fixes FL-1453

# Description
This PR introduces the following changes to the security context: 
- for all containers and initContainers: 
  - `spec.containers[*].securityContext.allowPrivilegeEscalation=false`
  - `spec.containers[*].securityContext.runAsNonRoot=true`
  - `spec.containers[*].securityContext.seccompProfile.type=RuntimeDefault`
  - `spec.containers[*].securityContext.capabilities.drop=["ALL"]`
 
The exceptions are : `add-cert` initContainer in several pods (if the local CA feature is used), `wait-registry` initContainer and `kaniko` initContainer in the registry-prepopulate pod. 

- for all pods: 
  - `spec.securityContext.runAsNonRoot=true`
  - `spec.securityContext.seccompProfile.type= RuntimeDefault`

The exceptions are the kaniko pods spawned by the builder.

# How to test: 

Deploy locally (with skaffold), and then apply labels: 
```
kubectl label --dry-run=server --overwrite ns org-2 pod-security.kubernetes.io/enforce=baseline
```

or 

```
kubectl label --dry-run=server --overwrite ns org-2 pod-security.kubernetes.io/enforce=restricted
```

The baseline profile should yield no warning. 
The restricted profile will show a few warnings, we are trying to remove.