### PR TITLE
chore(charts/substra-backend): handle whitespaced orgnames

### DIFF
--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 <!-- towncrier release notes start -->
+
+## [26.6.6] - 2024-06-03
+
+### Changed
+
+- Handle whitespaces in organization names during registration in migrations (#915)
+
 ## [26.6.5] - 2024-05-29
 
 ### Fixed
@@ -12,7 +19,7 @@
 ### Fixed
 
 - whitespace removal removed newline in `networkpolicy-orchestrator-client.yaml` (#914)
-  
+
 ## [26.6.3] - 2024-05-27
 
 ### Changed
@@ -25,7 +32,7 @@
 
 - Allow all ingress on server pod (#912)
 - Add a variable (`orchestrator.sameCluster`) to allow more communication between backend and orchestrator (#912)
-  
+
 ## [26.6.1] - 2024-05-23
 
 ### Fix

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: substra-backend
 home: https://github.com/Substra
-version: 26.6.5
+version: 26.6.6
 appVersion: 0.45.0
 kubeVersion: ">= 1.19.0-0"
 description: Main package for Substra

--- a/charts/substra-backend/templates/job-migrations.yaml
+++ b/charts/substra-backend/templates/job-migrations.yaml
@@ -47,9 +47,9 @@ spec:
             ## IncomingOrganization
             while IFS= read -r org_password; do
               # Extract the password as the last word
-              password=$(echo "$user_password" | awk '{print $NF}')
+              password=$(echo "$org_password" | awk '{print $NF}')
               # Extract the username by removing the last word
-              orgname=$(echo "$user_password" | sed 's/ [^ ]*$//')
+              orgname=$(echo "$org_password" | sed 's/ [^ ]*$//')
               ./manage.py create_incoming_organization "$orgname" "$password"
             done < /accounts/incoming_organizations
 

--- a/charts/substra-backend/templates/job-migrations.yaml
+++ b/charts/substra-backend/templates/job-migrations.yaml
@@ -45,15 +45,21 @@ spec:
             done < /accounts/users
 
             ## IncomingOrganization
-            while read -r user_password; do
-                read user password <<< "$user_password"
-                ./manage.py create_incoming_organization "$user" "$password"
+            while IFS= read -r org_password; do
+              # Extract the password as the last word
+              password=$(echo "$user_password" | awk '{print $NF}')
+              # Extract the username by removing the last word
+              orgname=$(echo "$user_password" | sed 's/ [^ ]*$//')
+              ./manage.py create_incoming_organization "$orgname" "$password"
             done < /accounts/incoming_organizations
 
             ## OutgoingOrganization
-            while read -r user_password; do
-                read user password <<< "$user_password"
-                ./manage.py create_outgoing_organization "$user" "$password"
+            while IFS= read -r org_password; do
+              # Extract the password as the last word
+              password=$(echo "$org_password" | awk '{print $NF}')
+              # Extract the username by removing the last word
+              orgname=$(echo "$org_password" | sed 's/ [^ ]*$//')
+              ./manage.py create_outgoing_organization "$orgname" "$password"
             done < /accounts/outgoing_organizations
         envFrom:
           - configMapRef:


### PR DESCRIPTION
## Description

Closes FL-1560

<!-- Please reference issue if any. -->

<!-- Please include a summary of your changes. -->

## How has this been tested?

### Locally

```bash
k logs backend-org-1-substra-backend-migrations-4krgq -n org-1
user created org-1
user created org-1-yourchannel
organization successfully created
organization_id=First Organization
organization successfully created
organization_id=MyOrg2MSP
organization successfully created
organization_id=MyOrg3MSP
outgoing organization successfully created
organization_id=First Organization
outgoing organization successfully created
organization_id=MyOrg2MSP
outgoing organization successfully created
organization_id=MyOrg3MSP
```

On the orchestrator db:
```sql
orchestrator=# select * from organizations;
         id         |   channel   |         creation_date         |                        address                         
--------------------+-------------+-------------------------------+--------------------------------------------------------
 First Organization | mychannel   | 2024-06-03 11:50:40.974187+00 | http://backend-org-1-substra-backend-server.org-1:8000
 First Organization | yourchannel | 2024-06-03 11:50:41.012371+00 | http://backend-org-1-substra-backend-server.org-1:8000
 MyOrg2MSP          | yourchannel | 2024-06-03 11:51:25.873426+00 | http://backend-org-2-substra-backend-server.org-2:8000
 MyOrg2MSP          | mychannel   | 2024-06-03 11:51:26.484685+00 | http://backend-org-2-substra-backend-server.org-2:8000
```

### CI

See: https://github.com/Substra/substra-backend/pull/909#issuecomment-2134748971

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
