### PR TITLE
fix: bypass asset failure creation when internal error

### DIFF
--- a/backend/api/events/sync.py
+++ b/backend/api/events/sync.py
@@ -406,7 +406,9 @@ def _on_create_failure_report_event(event: dict) -> None:
     asset_key = event["asset_key"]
     failure_report = event["failure_report"]
 
-    _create_failure_report(data=failure_report)
+    error_type = failure_report_pb2.ErrorType.Value(failure_report["error_type"])
+    if error_type != failure_report_pb2.ERROR_TYPE_INTERNAL:
+        _create_failure_report(data=failure_report)
 
     asset_type = failure_report_pb2.FailedAssetKind.Value(failure_report["asset_type"])
 

--- a/changes/924.fixed
+++ b/changes/924.fixed
@@ -1,0 +1,2 @@
+
+Bypass `AssetFailureReport` creation whenerror type is `ERROR_TYPE_INTERNAL`. It fixes errors when the backend receives an internal error from the orchestrator (without log address/checksum, as they are not provided in this scenario)

--- a/changes/924.fixed
+++ b/changes/924.fixed
@@ -1,2 +1,1 @@
-
 Bypass `AssetFailureReport` creation whenerror type is `ERROR_TYPE_INTERNAL`. It fixes errors when the backend receives an internal error from the orchestrator (without log address/checksum, as they are not provided in this scenario)


### PR DESCRIPTION
## Description

Bypass `AssetFailureReport` creation whenerror type is `ERROR_TYPE_INTERNAL`. It fixes errors when the backend receives an internal error from the orchestrator (without log address/checksum, as they are not provided in this scenario)

Fixes FL-1583

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
