### PR TITLE
chore(charts): allow using existing secrets

### DIFF
--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## [26.7.6] - 2024-07-03
+
+### Added
+
+- Allow using existing secrets for accountOperators, postgres, redis and objectstore
+
 ## [26.7.5] - 2024-06-29
 
 ### Added

--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 <!-- towncrier release notes start -->
 
-## [26.7.6] - 2024-07-03
+## [26.8.0] - 2024-07-05
 
 ### Added
 
 - Allow using existing secrets for accountOperators, postgres, redis and objectstore
+
+### Changed
+
+- `database.auth.credentialsSecretName` is now `database.auth.existingSecretName`
 
 ## [26.7.5] - 2024-06-29
 

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: substra-backend
 home: https://github.com/Substra
-version: 26.7.5
+version: "26.7.6-alpha.1"
 appVersion: 0.47.0
 kubeVersion: ">= 1.19.0-0"
 description: Main package for Substra

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: substra-backend
 home: https://github.com/Substra
-version: "26.7.6-alpha.4"
+version: "26.8.0"
 appVersion: 0.47.0
 kubeVersion: ">= 1.19.0-0"
 description: Main package for Substra

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: substra-backend
 home: https://github.com/Substra
-version: "26.7.6-alpha.3"
+version: "26.7.6-alpha.4"
 appVersion: 0.47.0
 kubeVersion: ">= 1.19.0-0"
 description: Main package for Substra

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: substra-backend
 home: https://github.com/Substra
-version: "26.7.6-alpha.2"
+version: "26.7.6-alpha.3"
 appVersion: 0.47.0
 kubeVersion: ">= 1.19.0-0"
 description: Main package for Substra

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: substra-backend
 home: https://github.com/Substra
-version: "26.7.6-alpha.1"
+version: "26.7.6-alpha.2"
 appVersion: 0.47.0
 kubeVersion: ">= 1.19.0-0"
 description: Main package for Substra

--- a/charts/substra-backend/README.md
+++ b/charts/substra-backend/README.md
@@ -325,12 +325,12 @@ See [UPGRADE.md](https://github.com/Substra/substra-backend/blob/main/charts/sub
 
 ### Account operator settings
 
-| Name                                       | Description                                                                                        | Value |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------------- | ----- |
-| `addAccountOperator.outgoingOrganizations` | Outgoing organizations credentials for substra backend organization-to-organization communications | `[]`  |
-| `addAccountOperator.incomingOrganizations` | Incoming organizations credentials for substra backend organization-to-organization communications | `[]`  |
-| `addAccountOperator.users`                 | A list of administrators users who can log into the substra backend server with admin privileges   | `[]`  |
-| `addAccountOperator.secretName`            | An alternative to providing credentials for organization-to-organization communications and users  | `""`  |
+| Name                                       | Description                                                                                                                                                                                  | Value |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| `addAccountOperator.outgoingOrganizations` | Outgoing organizations credentials for substra backend organization-to-organization communications                                                                                           | `[]`  |
+| `addAccountOperator.incomingOrganizations` | Incoming organizations credentials for substra backend organization-to-organization communications                                                                                           | `[]`  |
+| `addAccountOperator.users`                 | A list of administrators users who can log into the substra backend server with admin privileges                                                                                             | `[]`  |
+| `addAccountOperator.existingSecretName`    | An alternative to providing credentials for organization-to-organization communications and users ; secret must have the `users`, `incoming_organizations` and `outgoing_organizations` keys | `""`  |
 
 ### Registry prepopulate
 
@@ -377,14 +377,14 @@ Else, you must strike a balance: longer durations are more convenient, but risk 
 
 ### Database connection settings
 
-| Name                       | Description                                                                                                 | Value      |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------- |
-| `database.auth.database`   | what DB to connect to                                                                                       | `substra`  |
-| `database.auth.username`   | what user to connect as                                                                                     | `postgres` |
-| `database.auth.password`   | what password to use for connecting                                                                         | `postgres` |
-| `database.auth.secretName` | An alternative to giving username and password; must have `DATABASE_USERNAME` and `DATABASE_PASSWORD` keys. | `""`       |
-| `database.host`            | Hostname of the database to connect to (defaults to local)                                                  | `nil`      |
-| `database.port`            | Port of an external database to connect to                                                                  | `5432`     |
+| Name                               | Description                                                                                                 | Value      |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------- |
+| `database.auth.database`           | what DB to connect to                                                                                       | `substra`  |
+| `database.auth.username`           | what user to connect as                                                                                     | `postgres` |
+| `database.auth.password`           | what password to use for connecting                                                                         | `postgres` |
+| `database.auth.existingSecretName` | An alternative to giving username and password; must have `DATABASE_USERNAME` and `DATABASE_PASSWORD` keys. | `""`       |
+| `database.host`                    | Hostname of the database to connect to (defaults to local)                                                  | `nil`      |
+| `database.port`                    | Port of an external database to connect to                                                                  | `5432`     |
 
 ### PostgreSQL settings
 
@@ -392,10 +392,10 @@ Database included as a subchart used by default.
 
 See Bitnami documentation: https://bitnami.com/stack/postgresql/helm
 
-| Name                       | Description                                                                                                         | Value  |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------ |
-| `postgresql.enabled`       | Deploy a PostgreSQL instance along the backend for its use                                                          | `true` |
-| `database.auth.secretName` | An alternative to giving username and password; must have `OBJECTSTORE_ACCESSKEY` and `OBJECTSTORE_SECRETKEY` keys. | `""`   |
+| Name                               | Description                                                                                                         | Value  |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------ |
+| `postgresql.enabled`               | Deploy a PostgreSQL instance along the backend for its use                                                          | `true` |
+| `database.auth.existingSecretName` | An alternative to giving username and password; must have `OBJECTSTORE_ACCESSKEY` and `OBJECTSTORE_SECRETKEY` keys. | `""`   |
 
 ### Helm hooks
 

--- a/charts/substra-backend/README.md
+++ b/charts/substra-backend/README.md
@@ -330,7 +330,7 @@ See [UPGRADE.md](https://github.com/Substra/substra-backend/blob/main/charts/sub
 | `addAccountOperator.outgoingOrganizations` | Outgoing organizations credentials for substra backend organization-to-organization communications | `[]`  |
 | `addAccountOperator.incomingOrganizations` | Incoming organizations credentials for substra backend organization-to-organization communications | `[]`  |
 | `addAccountOperator.users`                 | A list of administrators users who can log into the substra backend server with admin privileges   | `[]`  |
-| `addAccountOperator.secretName`            | An alternative to giving:                                                                          | `""`  |
+| `addAccountOperator.secretName`            | An alternative to providing credentials for organization-to-organization communications and users  | `""`  |
 
 ### Registry prepopulate
 

--- a/charts/substra-backend/README.md
+++ b/charts/substra-backend/README.md
@@ -327,9 +327,10 @@ See [UPGRADE.md](https://github.com/Substra/substra-backend/blob/main/charts/sub
 
 | Name                                       | Description                                                                                        | Value |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------------- | ----- |
-| `addAccountOperator.outgoingOrganizations` | Outgoind organizations credentials for substra backend organization-to-organization communications | `[]`  |
+| `addAccountOperator.outgoingOrganizations` | Outgoing organizations credentials for substra backend organization-to-organization communications | `[]`  |
 | `addAccountOperator.incomingOrganizations` | Incoming organizations credentials for substra backend organization-to-organization communications | `[]`  |
 | `addAccountOperator.users`                 | A list of administrators users who can log into the substra backend server with admin privileges   | `[]`  |
+| `addAccountOperator.secretName`            | An alternative to giving:                                                                          | `""`  |
 
 ### Registry prepopulate
 
@@ -376,14 +377,14 @@ Else, you must strike a balance: longer durations are more convenient, but risk 
 
 ### Database connection settings
 
-| Name                                  | Description                                                                                                 | Value      |
-| ------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------- |
-| `database.auth.database`              | what DB to connect to                                                                                       | `substra`  |
-| `database.auth.username`              | what user to connect as                                                                                     | `postgres` |
-| `database.auth.password`              | what password to use for connecting                                                                         | `postgres` |
-| `database.auth.credentialsSecretName` | An alternative to giving username and password; must have `DATABASE_USERNAME` and `DATABASE_PASSWORD` keys. | `nil`      |
-| `database.host`                       | Hostname of the database to connect to (defaults to local)                                                  | `nil`      |
-| `database.port`                       | Port of an external database to connect to                                                                  | `5432`     |
+| Name                       | Description                                                                                                 | Value      |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------- |
+| `database.auth.database`   | what DB to connect to                                                                                       | `substra`  |
+| `database.auth.username`   | what user to connect as                                                                                     | `postgres` |
+| `database.auth.password`   | what password to use for connecting                                                                         | `postgres` |
+| `database.auth.secretName` | An alternative to giving username and password; must have `DATABASE_USERNAME` and `DATABASE_PASSWORD` keys. | `""`       |
+| `database.host`            | Hostname of the database to connect to (defaults to local)                                                  | `nil`      |
+| `database.port`            | Port of an external database to connect to                                                                  | `5432`     |
 
 ### PostgreSQL settings
 
@@ -391,9 +392,10 @@ Database included as a subchart used by default.
 
 See Bitnami documentation: https://bitnami.com/stack/postgresql/helm
 
-| Name                 | Description                                                | Value  |
-| -------------------- | ---------------------------------------------------------- | ------ |
-| `postgresql.enabled` | Deploy a PostgreSQL instance along the backend for its use | `true` |
+| Name                       | Description                                                                                                         | Value  |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------ |
+| `postgresql.enabled`       | Deploy a PostgreSQL instance along the backend for its use                                                          | `true` |
+| `database.auth.secretName` | An alternative to giving username and password; must have `OBJECTSTORE_ACCESSKEY` and `OBJECTSTORE_SECRETKEY` keys. | `""`   |
 
 ### Helm hooks
 

--- a/charts/substra-backend/templates/_helpers.tpl
+++ b/charts/substra-backend/templates/_helpers.tpl
@@ -404,8 +404,8 @@ Retrieve AWS environment variable value
 Define database secret name
 */}}
 {{- define "substra-backend.database.secretName" -}}
-    {{- if .Values.database.auth.secretName -}}
-        {{- .Values.database.auth.secretName }}
+    {{- if .Values.database.auth.existingSecretName -}}
+        {{- .Values.database.auth.existingSecretName }}
     {{- else -}}
         {{ include "substra.fullname" . }}-database
     {{- end -}}
@@ -415,8 +415,8 @@ Define database secret name
 Define redis secret name
 */}}
 {{- define "substra-backend.redis.secretName" -}}
-    {{- if .Values.redis.auth.secretName -}}
-        {{- .Values.database.auth.secretName }}
+    {{- if .Values.redis.auth.existingSecretName -}}
+        {{- .Values.database.auth.existingSecretName }}
     {{- else -}}
         {{ include "substra.fullname" . }}-redis
     {{- end -}}
@@ -426,8 +426,8 @@ Define redis secret name
 Define account operators secret name
 */}}
 {{- define "substra-backend.accountOperator.secretName" -}}
-    {{- if .Values.addAccountOperator.secretName -}}
-        {{- .Values.database.auth.secretName }}
+    {{- if .Values.addAccountOperator.existingSecretName -}}
+        {{- .Values.database.auth.existingSecretName }}
     {{- else -}}
         {{ include "substra.fullname" . }}-add-account
     {{- end -}}
@@ -437,8 +437,8 @@ Define account operators secret name
 Define object store secret name
 */}}
 {{- define "substra-backend.objectStore.secretName" -}}
-    {{- if .Values.redis.auth.secretName -}}
-        {{- .Values.database.auth.secretName }}
+    {{- if .Values.redis.auth.existingSecretName -}}
+        {{- .Values.database.auth.existingSecretName }}
     {{- else -}}
         {{ include "substra.fullname" . }}-objectstore
     {{- end -}}

--- a/charts/substra-backend/templates/_helpers.tpl
+++ b/charts/substra-backend/templates/_helpers.tpl
@@ -408,3 +408,48 @@ Retrieve AWS environment variable value
 {{- end -}}
 {{- $value -}}
 {{- end -}}
+
+
+{{/*
+Define database secret name
+*/}}
+{{- define "substra-backend.database.secretName" -}}
+    {{- if .Values.database.auth.secretName -}}
+        {{- .Values.database.auth.secretName }}
+    {{- else -}}
+        {{ include "substra.fullname" . }}-database
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Define redis secret name
+*/}}
+{{- define "substra-backend.redis.secretName" -}}
+    {{- if .Values.redis.auth.secretName -}}
+        {{- .Values.database.auth.secretName }}
+    {{- else -}}
+        {{ include "substra.fullname" . }}-redis
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Define account operators secret name
+*/}}
+{{- define "substra-backend.accountOperator.secretName" -}}
+    {{- if .Values.addAccountOperator.secretName -}}
+        {{- .Values.database.auth.secretName }}
+    {{- else -}}
+        {{ include "substra.fullname" . }}-add-account
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Define object store secret name
+*/}}
+{{- define "substra-backend.objectstore.secretName" -}}
+    {{- if .Values.redis.auth.secretName -}}
+        {{- .Values.database.auth.secretName }}
+    {{- else -}}
+        {{ include "substra.fullname" . }}-objectstore
+    {{- end -}}
+{{- end -}}

--- a/charts/substra-backend/templates/_helpers.tpl
+++ b/charts/substra-backend/templates/_helpers.tpl
@@ -216,14 +216,6 @@ example:
 {{- end -}}
 
 
-{{- define "substra-backend.database.secret-name" -}}
-    {{- if .Values.database.auth.credentialsSecretName -}}
-        {{- .Values.database.auth.credentialsSecretName }}
-    {{- else -}}
-        {{- template "substra.fullname" . }}-database
-    {{- end -}}
-{{- end -}}
-
 {{/*
 The hostname we should connect to (external is defined, otherwise integrated)
 */}}
@@ -331,7 +323,7 @@ The hostname we should connect to (external is defined, otherwise integrated)
   - configMapRef:
       name: {{ include "substra.fullname" . }}-settings
   - secretRef:
-      name: {{ include "substra-backend.database.secret-name" . }}
+      name: {{ include "substra-backend.database.secretName" . }}
   env:
   - name: DJANGO_SETTINGS_MODULE
     value: backend.settings.{{ .Values.settings }}
@@ -371,7 +363,6 @@ Define service port based on MinIO or LocalStack enablement
     {{- end -}}
 {{- end -}}
 
-
 {{/*
 Define objectstore access key based on MinIO or LocalStack enablement
 */}}
@@ -409,7 +400,6 @@ Retrieve AWS environment variable value
 {{- $value -}}
 {{- end -}}
 
-
 {{/*
 Define database secret name
 */}}
@@ -446,7 +436,7 @@ Define account operators secret name
 {{/*
 Define object store secret name
 */}}
-{{- define "substra-backend.objectstore.secretName" -}}
+{{- define "substra-backend.objectStore.secretName" -}}
     {{- if .Values.redis.auth.secretName -}}
         {{- .Values.database.auth.secretName }}
     {{- else -}}

--- a/charts/substra-backend/templates/deployment-api-events.yaml
+++ b/charts/substra-backend/templates/deployment-api-events.yaml
@@ -72,9 +72,9 @@ spec:
             - configMapRef:
                 name: {{ include "substra.fullname" . }}-redis
             - secretRef:
-                name: {{ include "substra.fullname" . }}-redis
+                name: {{ include "substra-backend.redis.secretName" . }}
             - secretRef:
-                name: {{ include "substra-backend.database.secret-name" . }}
+                name: {{ include "substra-backend.database.secretName" . }}
           readinessProbe:
             exec:
               command:

--- a/charts/substra-backend/templates/deployment-scheduler-worker.yaml
+++ b/charts/substra-backend/templates/deployment-scheduler-worker.yaml
@@ -72,9 +72,9 @@ spec:
             - configMapRef:
                 name: {{ include "substra.fullname" . }}-registry
             - secretRef:
-                name: {{ include "substra.fullname" . }}-redis
+                name: {{ include "substra-backend.redis.secretName" . }}
             - secretRef:
-                name: {{ include "substra-backend.database.secret-name" . }}
+                name: {{ include "substra-backend.database.secretName" . }}
           env:
             - name: NAMESPACE
               valueFrom:

--- a/charts/substra-backend/templates/deployment-scheduler.yaml
+++ b/charts/substra-backend/templates/deployment-scheduler.yaml
@@ -69,9 +69,9 @@ spec:
             - configMapRef:
                 name: {{ include "substra.fullname" . }}-registry
             - secretRef:
-                name: {{ include "substra.fullname" . }}-redis
+                name: {{ include "substra-backend.objectStore.secretName" . }}
             - secretRef:
-                name: {{ include "substra-backend.database.secret-name" . }}
+                name: {{ include "substra-backend.database.secretName" . }}
           env:
             - name: NAMESPACE
               valueFrom:

--- a/charts/substra-backend/templates/deployment-server.yaml
+++ b/charts/substra-backend/templates/deployment-server.yaml
@@ -70,13 +70,13 @@ spec:
           - configMapRef:
               name: {{ include "substra.fullname" . }}-orchestrator
           - secretRef:
-              name: {{ include "substra.fullname" . }}-objectstore
+              name: {{ include "substra-backend.objectStore.secretName" . }}
           - configMapRef:
               name: {{ include "substra.fullname" . }}-settings
           - configMapRef:
               name: {{ include "substra.fullname" . }}-database
           - secretRef:
-              name: {{ include "substra-backend.database.secret-name" . }}
+              name: {{ include "substra-backend.database.secretName" . }}
           - secretRef:
               name: {{ include "substra.fullname" . }}-server-key
           - configMapRef:
@@ -230,13 +230,13 @@ spec:
           - configMapRef:
               name: {{ include "substra.fullname" . }}-orchestrator
           - secretRef:
-              name: {{ include "substra.fullname" . }}-objectstore
+              name: {{ include "substra-backend.objectStore.secretName" . }}
           - configMapRef:
               name: {{ include "substra.fullname" . }}-database
           - configMapRef:
               name: {{ include "substra.fullname" . }}-settings
           - secretRef:
-              name: {{ include "substra-backend.database.secret-name" . }}
+              name: {{ include "substra-backend.database.secretName" . }}
         env:
         - name: DJANGO_SETTINGS_MODULE
           value: backend.settings.{{ .Values.settings }}

--- a/charts/substra-backend/templates/deployment-worker-events.yaml
+++ b/charts/substra-backend/templates/deployment-worker-events.yaml
@@ -74,9 +74,9 @@ spec:
             - configMapRef:
                 name: {{ include "substra.fullname" . }}-redis
             - secretRef:
-                name: {{ include "substra.fullname" . }}-redis
+                name: {{ include "substra-backend.redis.secretName" . }}
             - secretRef:
-                name: {{ include "substra-backend.database.secret-name" . }}
+                name: {{ include "substra-backend.database.secretName" . }}
           readinessProbe:
             exec:
               command:

--- a/charts/substra-backend/templates/job-migrations.yaml
+++ b/charts/substra-backend/templates/job-migrations.yaml
@@ -77,7 +77,7 @@ spec:
           - configMapRef:
               name: {{ include "substra.fullname" . }}-database
           - secretRef:
-              name: {{ include "substra-backend.database.secret-name" . }}
+              name: {{ include "substra-backend.database.secretName" . }}
         env:
           - name: DJANGO_SETTINGS_MODULE
             value: backend.settings.{{ .Values.settings }}
@@ -88,4 +88,4 @@ spec:
       volumes:
         - name: accounts
           secret:
-            secretName: {{ template "substra.fullname" . }}-add-account
+            secretName: {{ include "substra-backend.accountOperator.secretName" . }}

--- a/charts/substra-backend/templates/secret-add-account.yaml
+++ b/charts/substra-backend/templates/secret-add-account.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.addAccountOperator.secretName }}
+{{- if not .Values.addAccountOperator.existingSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/substra-backend/templates/secret-add-account.yaml
+++ b/charts/substra-backend/templates/secret-add-account.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "substra.fullname" . }}-add-account
+  name: {{ template "substra-backend.accountOperator.secretName" . }}
   labels:
     {{ include "substra.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ include "substra.name" . }}-add-account

--- a/charts/substra-backend/templates/secret-add-account.yaml
+++ b/charts/substra-backend/templates/secret-add-account.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.addAccountOperator.secretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ data:
   users: {{ include "common.users" .Values.addAccountOperator.users | b64enc | quote }}
   incoming_organizations: {{ include "common.users" .Values.addAccountOperator.incomingOrganizations | b64enc | quote }}
   outgoing_organizations: {{ include "common.users" .Values.addAccountOperator.outgoingOrganizations | b64enc | quote }}
+{{- end }}

--- a/charts/substra-backend/templates/secret-database.yaml
+++ b/charts/substra-backend/templates/secret-database.yaml
@@ -7,6 +7,6 @@ metadata:
   {{- include "substra.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  DATABASE_PASSWORD: "{{ .Values.database.auth.password | quote }}"
-  DATABASE_USERNAME: "{{ .Values.database.auth.username | quote }}"
+  DATABASE_PASSWORD: '{{ .Values.database.auth.password | quote }}'
+  DATABASE_USERNAME: '{{ .Values.database.auth.username | quote }}'
 {{- end }}

--- a/charts/substra-backend/templates/secret-database.yaml
+++ b/charts/substra-backend/templates/secret-database.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.database.auth.credentialsSecretName }}
+{{- if not .Values.database.auth.secretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,6 +7,6 @@ metadata:
   {{- include "substra.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  DATABASE_PASSWORD: {{ .Values.database.auth.password | quote }}
-  DATABASE_USERNAME: {{ .Values.database.auth.username | quote }}
+  DATABASE_PASSWORD: "{{ .Values.database.auth.password | quote }}"
+  DATABASE_USERNAME: "{{ .Values.database.auth.username | quote }}"
 {{- end }}

--- a/charts/substra-backend/templates/secret-database.yaml
+++ b/charts/substra-backend/templates/secret-database.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.database.auth.secretName }}
+{{- if not .Values.database.auth.existingSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/substra-backend/templates/secret-database.yaml
+++ b/charts/substra-backend/templates/secret-database.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
   {{- include "substra.labels" . | nindent 4 }}
 type: Opaque
-stringData:
-  DATABASE_PASSWORD: '{{ .Values.database.auth.password | quote }}'
-  DATABASE_USERNAME: '{{ .Values.database.auth.username | quote }}'
+data:
+  DATABASE_PASSWORD: {{ .Values.database.auth.password | b64enc | quote }}
+  DATABASE_USERNAME: {{ .Values.database.auth.username | b64enc | quote }}
 {{- end }}

--- a/charts/substra-backend/templates/secret-database.yaml
+++ b/charts/substra-backend/templates/secret-database.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "substra.fullname" . }}-database
+  name: {{ template "substra-backend.database.secretName" . }}
   labels:
   {{- include "substra.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/substra-backend/templates/secret-objectstore.yaml
+++ b/charts/substra-backend/templates/secret-objectstore.yaml
@@ -1,4 +1,4 @@
-{{- if or (not .Values.minio.auth.secretName) .Values.localstack.enabled }}
+{{- if or (not .Values.minio.auth.existingSecretName) .Values.localstack.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/substra-backend/templates/secret-objectstore.yaml
+++ b/charts/substra-backend/templates/secret-objectstore.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "substra-backend.objectstore.secretName" . }}
+  name: {{ template "substra-backend.objectStore.secretName" . }}
   labels:
     {{ include "substra.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ include "substra.name" . }}

--- a/charts/substra-backend/templates/secret-objectstore.yaml
+++ b/charts/substra-backend/templates/secret-objectstore.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "substra.fullname" . }}-objectstore
+  name: {{ template "substra-backend.objectstore.secretName" . }}
   labels:
     {{ include "substra.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ include "substra.name" . }}

--- a/charts/substra-backend/templates/secret-objectstore.yaml
+++ b/charts/substra-backend/templates/secret-objectstore.yaml
@@ -1,3 +1,4 @@
+{{- if or (not .Values.minio.auth.secretName) .Values.localstack.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ type: Opaque
 data:
   OBJECTSTORE_ACCESSKEY: {{ include "substra-backend.objectStore.accessKey" . | b64enc }}
   OBJECTSTORE_SECRETKEY: {{ include "substra-backend.objectStore.secretKey" . | b64enc }}
+{{- end }}

--- a/charts/substra-backend/templates/secret-redis.yaml
+++ b/charts/substra-backend/templates/secret-redis.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.redis.auth.secretName }}
+{{- if not .Values.redis.auth.existingSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/substra-backend/templates/secret-redis.yaml
+++ b/charts/substra-backend/templates/secret-redis.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.redis.auth.secretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
 type: Opaque
 data:
   CELERY_BROKER_PASSWORD: {{ .Values.redis.auth.password | b64enc | quote }}
+{{- end }}

--- a/charts/substra-backend/templates/secret-redis.yaml
+++ b/charts/substra-backend/templates/secret-redis.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "substra.fullname" . }}-redis
+  name: {{ template "substra-backend.redis.secretName" . }}
   labels:
   {{- include "substra.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/substra-backend/templates/statefulset-builder.yaml
+++ b/charts/substra-backend/templates/statefulset-builder.yaml
@@ -146,12 +146,12 @@ spec:
           - configMapRef:
                 name: {{ include "substra.fullname" . }}-database
           - secretRef:
-              name: {{ include "substra.fullname" . }}-objectstore
+              name: {{ include "substra-backend.objectStore.secretName" . }}
           - secretRef:
-              name: {{ include "substra.fullname" . }}-redis
+              name: {{ include "substra-backend.redis.secretName" . }}
           # TODO: Remove once moved ImageResitryEntrypoint logic
           - secretRef:
-                name: {{ include "substra-backend.database.secret-name" . }}
+              name: {{ include "substra-backend.database.secretName" . }}
         env:
           - name: HOST_IP
             valueFrom:

--- a/charts/substra-backend/templates/statefulset-worker.yaml
+++ b/charts/substra-backend/templates/statefulset-worker.yaml
@@ -102,11 +102,11 @@ spec:
             - configMapRef:
                 name: {{ include "substra.fullname" . }}-registry
             - secretRef:
-                name: {{ include "substra.fullname" . }}-objectstore
+                name: {{ include "substra-backend.objectStore.secretName" . }}
             - secretRef:
-                name: {{ include "substra.fullname" . }}-redis
+                name: {{ include "substra-backend.redis.secretName" . }}
             - secretRef:
-                name: {{ include "substra-backend.database.secret-name" . }}
+                name: {{ include "substra-backend.database.secretName" . }}
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: backend.settings.celery.{{ .Values.settings }}

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -820,11 +820,6 @@ kaniko:
 ## @section Account operator settings
 ##
 addAccountOperator:
-  ## @param addAccountOperator.secretName name of the Secret gathering information related to:
-  ##   - organization-to-organization communications (outgoingOrganizations and incomingOrganizations)
-  ##   - users who can log into the substra backend server with admin privileges
-  ##
-  secretName: ""
   ## @param addAccountOperator.outgoingOrganizations Outgoing organizations credentials for substra backend organization-to-organization communications
   ## e.g:
   ## - name: organizationId
@@ -844,6 +839,11 @@ addAccountOperator:
   ##   channel: mychannel
   ##
   users: []
+  ## @param addAccountOperator.secretName An alternative to giving:
+  ##   - organization-to-organization communications (outgoingOrganizations and incomingOrganizations)
+  ##   - users who can log into the substra backend server with admin privileges
+  ## Secret must have the `users`, `incoming_organizations` and `outgoing_organizations` keys
+  secretName: ""
 
 ## @section Registry prepopulate
 ##

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -994,7 +994,6 @@ redis:
   architecture: standalone
   auth:
     password: redis
-    ## @param redis.auth.secretName An alternative to giving username and password; must have `CELERY_BROKER_PASSWORD` key.
     secretName: ""
   master:
     persistence:

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -839,9 +839,8 @@ addAccountOperator:
   ##   channel: mychannel
   ##
   users: []
-  ## @param addAccountOperator.secretName An alternative to providing credentials for organization-to-organization communications and users
-  ## Secret must have the `users`, `incoming_organizations` and `outgoing_organizations` keys
-  secretName: ""
+  ## @param addAccountOperator.existingSecretName An alternative to providing credentials for organization-to-organization communications and users ; secret must have the `users`, `incoming_organizations` and `outgoing_organizations` keys
+  existingSecretName: ""
 
 ## @section Registry prepopulate
 ##
@@ -934,10 +933,9 @@ database:
     username: &psql-username postgres
     ## @param database.auth.password what password to use for connecting
     password: &psql-password postgres
-
-    ## @param database.auth.secretName An alternative to giving username and password; must have `DATABASE_USERNAME` and `DATABASE_PASSWORD` keys.
+    ## @param database.auth.existingSecretName An alternative to giving username and password; must have `DATABASE_USERNAME` and `DATABASE_PASSWORD` keys.
     ##
-    secretName: ""
+    existingSecretName: ""
 
   ## @param database.host Hostname of the database to connect to (defaults to local)
   host: null
@@ -961,6 +959,7 @@ postgresql:
     username: *psql-username
     password: *psql-password
     database: *psql-database
+
   ## @skip postgresql.primary
   primary:
     resources:
@@ -992,7 +991,7 @@ redis:
   architecture: standalone
   auth:
     password: redis
-    secretName: ""
+    existingSecretName: ""
   master:
     persistence:
       enabled: true
@@ -1065,8 +1064,8 @@ minio:
     forcePassword: true
     ## required to take into account new access and secret keys
     forceNewKeys: true
-    ## @param database.auth.secretName An alternative to giving username and password; must have `OBJECTSTORE_ACCESSKEY` and `OBJECTSTORE_SECRETKEY` keys.
-    secretName: ""
+    ## @param database.auth.existingSecretName An alternative to giving username and password; must have `OBJECTSTORE_ACCESSKEY` and `OBJECTSTORE_SECRETKEY` keys.
+    existingSecretName: ""
   resources:
     requests:
       cpu: "500m"

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -820,7 +820,12 @@ kaniko:
 ## @section Account operator settings
 ##
 addAccountOperator:
-  ## @param addAccountOperator.outgoingOrganizations Outgoind organizations credentials for substra backend organization-to-organization communications
+  ## @param addAccountOperator.secretName name of the Secret gathering information related to:
+  ##   - organization-to-organization communications (outgoingOrganizations and incomingOrganizations)
+  ##   - users who can log into the substra backend server with admin privileges
+  ##
+  secretName: ""
+  ## @param addAccountOperator.outgoingOrganizations Outgoing organizations credentials for substra backend organization-to-organization communications
   ## e.g:
   ## - name: organizationId
   ##   secret: organizationSecret
@@ -932,9 +937,9 @@ database:
     ## @param database.auth.password what password to use for connecting
     password: &psql-password postgres
 
-    ## @param database.auth.credentialsSecretName An alternative to giving username and password; must have `DATABASE_USERNAME` and `DATABASE_PASSWORD` keys.
+    ## @param database.auth.secretName An alternative to giving username and password; must have `DATABASE_USERNAME` and `DATABASE_PASSWORD` keys.
     ##
-    credentialsSecretName: null
+    secretName: ""
 
   ## @param database.host Hostname of the database to connect to (defaults to local)
   host: null
@@ -989,6 +994,8 @@ redis:
   architecture: standalone
   auth:
     password: redis
+    ## @param redis.auth.secretName An alternative to giving username and password; must have `CELERY_BROKER_PASSWORD` key.
+    secretName: ""
   master:
     persistence:
       enabled: true
@@ -1061,6 +1068,8 @@ minio:
     forcePassword: true
     ## required to take into account new access and secret keys
     forceNewKeys: true
+    ## @param database.auth.secretName An alternative to giving username and password; must have `OBJECTSTORE_ACCESSKEY` and `OBJECTSTORE_SECRETKEY` keys.
+    secretName: ""
   resources:
     requests:
       cpu: "500m"
@@ -1114,7 +1123,6 @@ localstack:
       value: "helloAws"
     - name: AWS_SECRET_ACCESS_KEY
       value: "mySuperSecureAWSAccessKey1234"
-
   persistence:
     enabled: true
     accessMode: ReadWriteOnce

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -839,9 +839,7 @@ addAccountOperator:
   ##   channel: mychannel
   ##
   users: []
-  ## @param addAccountOperator.secretName An alternative to giving:
-  ##   - organization-to-organization communications (outgoingOrganizations and incomingOrganizations)
-  ##   - users who can log into the substra backend server with admin privileges
+  ## @param addAccountOperator.secretName An alternative to providing credentials for organization-to-organization communications and users
   ## Secret must have the `users`, `incoming_organizations` and `outgoing_organizations` keys
   secretName: ""
 


### PR DESCRIPTION
## Description

<!-- Please reference issue if any. -->

Part of FL-1642

<!-- Please include a summary of your changes. -->

* Add `existingSecretName` key for the following sections
  * `database`
  * `addAccountOperator`
  * `redis`
  * `minio`
 * Enabled `existingSecret` key for `postgres` section (see [docs](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml#L35))
 * Added helpers to define the secret name based on whether one was provided
 * Injected new secret-name templates in deployments

## How has this been tested?

* https://github.com/Substra/substra-backend/pull/948
  * https://github.com/owkin/substra-ci/actions/runs/9796961654/job/27052532307
  * https://github.com/owkin/substra-ci/actions/runs/9797285704/job/27053575156
* https://github.com/owkin/substra-flux/pull/256

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [x] [changelog](../CHANGELOG.md) was updated with notable changes
- [] documentation was updated
