### PR TITLE
chore: switch from mantis (`23.10`) to next LTS (`24.04`)

### DIFF
--- a/docker/ca-cert-injector/Dockerfile
+++ b/docker/ca-cert-injector/Dockerfile
@@ -1,3 +1,3 @@
-FROM ubuntu:mantic
+FROM ubuntu:24.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates openssl && rm -rf /var/lib/apt/lists/* && update-ca-certificates 

--- a/docker/substra-backend/Dockerfile
+++ b/docker/substra-backend/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update -y \
     && apt-get install --no-install-recommends -y --only-upgrade gnupg \
-    && apt-get --no-install-recommends -y install software-properties-common python3-pip gcc python3.11-dev python3-watchdog celery python-is-python3 python3.11-venv \
+    && apt-get --no-install-recommends -y install software-properties-common python3-pip gcc python3-dev python3-watchdog celery python-is-python3 python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app

--- a/docker/substra-backend/Dockerfile
+++ b/docker/substra-backend/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /usr/src/app
 
 COPY ./backend/requirements.txt /usr/src/app/.
 
-RUN python3.11 -m venv /venv
+RUN python -m venv /venv
 ENV PATH="/venv/bin:$PATH" VIRTUAL_ENV="/venv"
 
 RUN pip install --upgrade --no-cache-dir pip==24.0 \

--- a/docker/substra-backend/Dockerfile
+++ b/docker/substra-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10 AS build
+FROM ubuntu:24.04 AS build
 
 ENV GRPC_POLL_STRATEGY=epoll1
 ENV PYTHONUNBUFFERED=1
@@ -52,7 +52,7 @@ COPY ./backend/dev-requirements.txt /usr/src/app/.
 RUN pip install --no-cache-dir -r dev-requirements.txt
 COPY backend/dev-startup.sh .
 
-FROM ubuntu:23.10
+FROM ubuntu:24.04
 
 ARG VERSION
 ENV BACKEND_VERSION=${VERSION:-dev}


### PR DESCRIPTION
## Description

Fix error in substra-ci due to a removal of ubuntu mantis repository.

Ci ran well with the update (test only on sdk): https://github.com/owkin/substra-ci/actions/runs/12429276467

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.  -->

## Checklist

- [ ] [changelog](../CHANGELOG.md) was updated with notable changes
- [ ] documentation was updated
